### PR TITLE
generalize cmake to build for different cuda archs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(torchfort CXX Fortran)
 
 # Set TORCH_CUDA_ARCH_LIST string to match TORCHFORT_CUDA_CC_LIST
 foreach(CUDA_CC ${TORCHFORT_CUDA_CC_LIST})
-  string(REPLACE "0" ".0" CUDA_CC_W_DOT ${CUDA_CC})
+    string(REGEX REPLACE "([0-9])$" ".\\1" CUDA_CC_W_DOT ${CUDA_CC})
   list(APPEND TORCH_CUDA_ARCH_LIST ${CUDA_CC_W_DOT})
 endforeach()
 list(JOIN TORCH_CUDA_ARCH_LIST " " TORCH_CUDA_ARCH_LIST)


### PR DESCRIPTION
## Problem

My GPU has a CUDA architecture of `89` (GTX 4080). Currently the `CMakeLists.txt` is only setup to handle architectures that end in `0`.

## Solution

 I modified the string replacement to handle generic CUDA architectures.

Fixes #8 

## Notes

Also currently `CMakeLists.txt` only builds `70` and `80` by default. You will have to add `89` to `TORCHFORT_CUDA_CC_LIST` in the following line if you want to build for all 3 (i.e., `TORCHFORT_CUDA_CC_LIST "70;80;89"`).
https://github.com/NVIDIA/TorchFort/blob/e06613d6feccc3d11c166f146abce7abdd85f1b3/CMakeLists.txt#L5

If you do not add 89 to `TORCHFORT_CUDA_CC_LIST` you will get the following error when you try to run the binary.

```
Accelerator Fatal Error: This file was compiled: -acc=gpu -gpu=cc70 -gpu=cc80 -acc=host or -acc=multicore
Rebuild this file with -gpu=cc89 to use NVIDIA Tesla GPU 0
```
