### PR TITLE
Enable builds without CUDA/GPU support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TORCHFORT_YAML_CPP_ROOT CACHE STRING "Path to search for yaml-cpp installati
 option(TORCHFORT_BUILD_FORTRAN "Build Fortran bindings" ON)
 option(TORCHFORT_BUILD_EXAMPLES "Build examples" OFF)
 option(TORCHFORT_BUILD_TESTS "Build tests" OFF)
+option(TORCHFORT_ENABLE_GPU "Enable GPU/CUDA support" ON)
 
 # For backward-compatibility with existing variable
 if (YAML_CPP_ROOT)
@@ -54,50 +55,52 @@ endif()
 find_package(MPI REQUIRED)
 
 # CUDA
-find_package(CUDAToolkit REQUIRED)
+if (TORCHFORT_ENABLE_GPU)
+  find_package(CUDAToolkit REQUIRED)
 
-# HPC SDK
-# Locate and append NVHPC CMake configuration if available
-find_program(NVHPC_CXX_BIN "nvc++")
-if (NVHPC_CXX_BIN)
-  string(REPLACE "compilers/bin/nvc++" "cmake" NVHPC_CMAKE_DIR ${NVHPC_CXX_BIN})
-  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${NVHPC_CMAKE_DIR}")
-  find_package(NVHPC COMPONENTS "")
-endif()
-
-# Get NCCL library (with optional override)
-if (TORCHFORT_NCCL_ROOT)
-  find_path(NCCL_INCLUDE_DIR REQUIRED
-    NAMES nccl.h
-    HINTS ${TORCHFORT_NCCL_ROOT}/include
-  )
-
-  find_library(NCCL_LIBRARY REQUIRED
-    NAMES nccl
-    HINTS ${TORCHFORT_NCCL_ROOT}/lib
-  )
-else()
-  if (NVHPC_FOUND)
-    find_package(NVHPC REQUIRED COMPONENTS NCCL)
-    find_library(NCCL_LIBRARY
-      NAMES nccl
-      HINTS ${NVHPC_NCCL_LIBRARY_DIR}
-    )
-    string(REPLACE "/lib" "/include" NCCL_INCLUDE_DIR ${NVHPC_NCCL_LIBRARY_DIR})
-  else()
-    message(FATAL_ERROR "Cannot find NCCL library. Please set TORCHFORT_NCCL_ROOT to NCCL installation directory.")
+  # HPC SDK
+  # Locate and append NVHPC CMake configuration if available
+  find_program(NVHPC_CXX_BIN "nvc++")
+  if (NVHPC_CXX_BIN)
+    string(REPLACE "compilers/bin/nvc++" "cmake" NVHPC_CMAKE_DIR ${NVHPC_CXX_BIN})
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${NVHPC_CMAKE_DIR}")
+    find_package(NVHPC COMPONENTS "")
   endif()
+  
+  # Get NCCL library (with optional override)
+  if (TORCHFORT_NCCL_ROOT)
+    find_path(NCCL_INCLUDE_DIR REQUIRED
+      NAMES nccl.h
+      HINTS ${TORCHFORT_NCCL_ROOT}/include
+    )
+  
+    find_library(NCCL_LIBRARY REQUIRED
+      NAMES nccl
+      HINTS ${TORCHFORT_NCCL_ROOT}/lib
+    )
+  else()
+    if (NVHPC_FOUND)
+      find_package(NVHPC REQUIRED COMPONENTS NCCL)
+      find_library(NCCL_LIBRARY
+        NAMES nccl
+        HINTS ${NVHPC_NCCL_LIBRARY_DIR}
+      )
+      string(REPLACE "/lib" "/include" NCCL_INCLUDE_DIR ${NVHPC_NCCL_LIBRARY_DIR})
+    else()
+      message(FATAL_ERROR "Cannot find NCCL library. Please set TORCHFORT_NCCL_ROOT to NCCL installation directory.")
+    endif()
+  endif()
+  
+  message(STATUS "Using NCCL library: ${NCCL_LIBRARY}")
+
+  # PyTorch
+  # Set TORCH_CUDA_ARCH_LIST string to match TORCHFORT_CUDA_CC_LIST
+  foreach(CUDA_CC ${TORCHFORT_CUDA_CC_LIST})
+      string(REGEX REPLACE "([0-9])$" ".\\1" CUDA_CC_W_DOT ${CUDA_CC})
+    list(APPEND TORCH_CUDA_ARCH_LIST ${CUDA_CC_W_DOT})
+  endforeach()
+  list(JOIN TORCH_CUDA_ARCH_LIST " " TORCH_CUDA_ARCH_LIST)
 endif()
-
-message(STATUS "Using NCCL library: ${NCCL_LIBRARY}")
-
-# PyTorch
-# Set TORCH_CUDA_ARCH_LIST string to match TORCHFORT_CUDA_CC_LIST
-foreach(CUDA_CC ${TORCHFORT_CUDA_CC_LIST})
-    string(REGEX REPLACE "([0-9])$" ".\\1" CUDA_CC_W_DOT ${CUDA_CC})
-  list(APPEND TORCH_CUDA_ARCH_LIST ${CUDA_CC_W_DOT})
-endforeach()
-list(JOIN TORCH_CUDA_ARCH_LIST " " TORCH_CUDA_ARCH_LIST)
 
 find_package(Torch REQUIRED)
 
@@ -160,16 +163,22 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${NCCL_LIBRARY})
 target_link_libraries(${PROJECT_NAME} PRIVATE MPI::MPI_CXX)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${YAML_CPP_LIBRARY})
-target_link_libraries(${PROJECT_NAME} PRIVATE CUDA::cudart)
 
 target_include_directories(${PROJECT_NAME}
     PRIVATE
     ${YAML_CPP_INCLUDE_DIR}
     ${MPI_CXX_INCLUDE_DIRS}
     ${TORCH_INCLUDE_DIRS}
+)
+if (TORCHFORT_ENABLE_GPU)
+  target_include_directories(${PROJECT_NAME}
+    PRIVATE
     ${CUDAToolkit_INCLUDE_DIRS}
     ${NCCL_INCLUDE_DIR}
-)
+  )
+  target_link_libraries(${PROJECT_NAME} PRIVATE CUDA::cudart)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_GPU)
+endif()
 target_compile_definitions(${PROJECT_NAME} PRIVATE YAML_CPP_STATIC_DEFINE)
 target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${TORCH_CXX_FLAGS}>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,10 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs DESTINATION ${CMAKE_INSTALL_P
 
 # build examples
 if (TORCHFORT_BUILD_EXAMPLES)
-  add_subdirectory(examples/cpp/cart_pole)
+  if (TORCHFORT_ENABLE_GPU)
+    # TODO: Enable cart_pole example for CPU only builds
+    add_subdirectory(examples/cpp/cart_pole)
+  endif()
   if (TORCHFORT_BUILD_FORTRAN)
     add_subdirectory(examples/fortran/simulation)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,10 +243,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs DESTINATION ${CMAKE_INSTALL_P
 
 # build examples
 if (TORCHFORT_BUILD_EXAMPLES)
-  if (TORCHFORT_ENABLE_GPU)
-    # TODO: Enable cart_pole example for CPU only builds
-    add_subdirectory(examples/cpp/cart_pole)
-  endif()
+  add_subdirectory(examples/cpp/cart_pole)
   if (TORCHFORT_BUILD_FORTRAN)
     add_subdirectory(examples/fortran/simulation)
   endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV CUDA_HOME /opt/nvidia/hpc_sdk/Linux_x86_64/24.1/cuda
 
 RUN echo "source /opt/nvidia/hpc_sdk/Linux_x86_64/24.1/comm_libs/12.3/hpcx/latest/hpcx-init.sh; hpcx_load" >>  /root/.bashrc
 
-# Install NCCL 2.20.3 for compatibility with PyTorch 2.2.1
+# Install newer NCCL for compatibility with PyTorch 2.2.1+
 RUN cd /opt && \
     git clone --branch v2.20.3-1 https://github.com/NVIDIA/nccl.git && \
     cd nccl && \
@@ -74,7 +74,7 @@ RUN cd /torchfort && mkdir build && cd build && \
     -DTORCHFORT_BUILD_TESTS=1 \
     -DCMAKE_PREFIX_PATH="`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`" \
     .. && \
-    make VERBOSE=1 -j$(nproc) install && \
+    make -j$(nproc) install && \
     cd / && rm -rf torchfort
 ENV LD_LIBRARY_PATH /opt/torchfort/lib:${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH /usr/local/lib/python3.10/dist-packages/torch/lib:${LD_LIBRARY_PATH}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /opt && \
 ENV LD_LIBRARY_PATH /opt/nccl/build/lib:$LD_LIBRARY_PATH
 
 # Install PyTorch
-RUN pip3 install torch==2.2.1 torchvision torchaudio
+RUN pip3 install torch==2.4.0
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \

--- a/docker/Dockerfile_cpu
+++ b/docker/Dockerfile_cpu
@@ -1,0 +1,55 @@
+FROM ubuntu:22.04
+
+# Install System Dependencies
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update -y && \
+    apt install -y build-essential && \
+    apt install -y curl unzip wget cmake python3 python-is-python3 python3-pip python3-pybind11 git vim gfortran doxygen libibverbs-dev
+
+# Download HPCX and compile with Fortran support
+RUN cd /opt && \
+    wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz && \
+    tar xzf openmpi-5.0.5.tar.gz && \
+    cd openmpi-5.0.5 && \
+    FC=gfortran CC=gcc CXX=g++ ./configure --prefix=/opt/openmpi \
+                                           --with-libevent=internal \
+                                           --enable-mpi1-compatibility \
+                                           --without-xpmem \
+                                           --with-slurm && \
+    make -j$(nproc) install && \
+    cd /opt && rm -rf openmpi-5.0.5 && rm openmpi-5.0.5.tar.gz 
+
+ENV PATH /opt/openmpi/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
+
+# Install PyTorch
+RUN pip3 install torch==2.2.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+
+# Install yaml-cpp
+RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
+    cd yaml-cpp && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt/yaml-cpp \
+          -DCMAKE_CXX_FLAGS:="-D_GLIBCXX_USE_CXX11_ABI=0" \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && \
+    make -j$(nproc) && make install
+ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
+
+# Install HDF5
+RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_3.tar.gz && \
+    tar xzf hdf5-1_14_3.tar.gz && \
+    cd hdf5-hdf5-1_14_3 && \
+    CC=mpicc FC=mpifort \
+    ./configure --enable-parallel \
+                --enable-fortran \
+                --prefix=/opt/hdf5 && \
+    make -j$(nproc) install && \
+    cd .. && \
+    rm -rf hdf5-hdf5-1_14_3 hdf5-1_14_3.tar.gz
+ENV LD_LIBRARY_PATH /opt/hdf5/lib:$LD_LIBRARY_PATH
+
+# Install additional Python dependencies
+RUN pip3 install wandb ruamel-yaml h5py matplotlib pygame moviepy
+
+ENTRYPOINT bash

--- a/docker/Dockerfile_gnu
+++ b/docker/Dockerfile_gnu
@@ -1,8 +1,12 @@
 FROM nvcr.io/nvidia/cuda:12.3.1-devel-ubuntu22.04
 
 # Install System Dependencies
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y && \
-    DEBIAN_FRONTEND=noninteractive apt install -y curl unzip wget cmake python3 python-is-python3 python3-pip python3-pybind11 git vim gfortran doxygen libibverbs-dev
+    apt install -y curl unzip wget cmake && \
+    apt install -y python3 python-is-python3 python3-pip python3-pybind11 && \
+    apt install -y git vim gfortran doxygen && \
+    apt install -y libibverbs-dev ibverbs-utils numactl
 
 # Download HPCX and compile with Fortran support
 RUN cd /opt && \
@@ -32,7 +36,7 @@ ENV LD_LIBRARY_PATH /opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
 
 RUN echo "source /opt/hpcx/hpcx-init.sh; hpcx_load" >>  /root/.bashrc
 
-# Install NCCL 2.20.3 for compatibility with PyTorch 2.2.1
+# Install newer NCCL for compatibility with PyTorch 2.2.1+
 RUN cd /opt && \
     git clone --branch v2.20.3-1 https://github.com/NVIDIA/nccl.git && \
     cd nccl && \
@@ -40,7 +44,7 @@ RUN cd /opt && \
 ENV LD_LIBRARY_PATH /opt/nccl/build/lib:$LD_LIBRARY_PATH
 
 # Install PyTorch
-RUN pip3 install torch==2.2.1 torchvision torchaudio
+RUN pip3 install torch==2.4.0
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
@@ -78,6 +82,7 @@ RUN cd /torchfort && mkdir build && cd build && \
     -DTORCHFORT_YAML_CPP_ROOT=/opt/yaml-cpp \
     -DTORCHFORT_NCCL_ROOT=/opt/nccl/build \
     -DTORCHFORT_BUILD_EXAMPLES=1 \
+    -DTORCHFORT_BUILD_TESTS=1 \
     -DCMAKE_PREFIX_PATH="`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`" \
     .. && \
     make -j$(nproc) install && \

--- a/docker/Dockerfile_gnu_cpuonly
+++ b/docker/Dockerfile_gnu_cpuonly
@@ -6,7 +6,7 @@ RUN apt update -y && \
     apt install -y build-essential && \
     apt install -y curl unzip wget cmake python3 python-is-python3 python3-pip python3-pybind11 git vim gfortran doxygen libibverbs-dev
 
-# Download HPCX and compile with Fortran support
+# Download OpenMPI and compile with Fortran support
 RUN cd /opt && \
     wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz && \
     tar xzf openmpi-5.0.5.tar.gz && \
@@ -23,7 +23,7 @@ ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 
 # Install PyTorch
-RUN pip3 install torch==2.2.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install torch==2.4.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
@@ -51,5 +51,22 @@ ENV LD_LIBRARY_PATH /opt/hdf5/lib:$LD_LIBRARY_PATH
 
 # Install additional Python dependencies
 RUN pip3 install wandb ruamel-yaml h5py matplotlib pygame moviepy
+
+# Install TorchFort without GPU support
+ENV FC=gfortran
+ENV HDF5_ROOT=/opt/hdf5
+COPY . /torchfort
+RUN cd /torchfort && mkdir build && cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt/torchfort \
+    -DTORCHFORT_YAML_CPP_ROOT=/opt/yaml-cpp \
+    -DTORCHFORT_ENABLE_GPU=0 \
+    -DTORCHFORT_BUILD_EXAMPLES=1 \
+    -DTORCHFORT_BUILD_TESTS=1 \
+    -DCMAKE_PREFIX_PATH="`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`" \
+    .. && \
+    make -j$(nproc) install && \
+    cd / && rm -rf torchfort
+ENV LD_LIBRARY_PATH /opt/torchfort/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH /usr/local/lib/python3.10/dist-packages/torch/lib:${LD_LIBRARY_PATH}
 
 ENTRYPOINT bash

--- a/docker/Dockerfile_gnu_cpuonly
+++ b/docker/Dockerfile_gnu_cpuonly
@@ -4,7 +4,10 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y && \
     apt install -y build-essential && \
-    apt install -y curl unzip wget cmake python3 python-is-python3 python3-pip python3-pybind11 git vim gfortran doxygen libibverbs-dev
+    apt install -y curl unzip wget cmake && \
+    apt install -y python3 python-is-python3 python3-pip python3-pybind11 && \
+    apt install -y git vim gfortran doxygen && \
+    apt install -y libibverbs-dev ibverbs-utils numactl
 
 # Download OpenMPI and compile with Fortran support
 RUN cd /opt && \
@@ -23,7 +26,7 @@ ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 
 # Install PyTorch
-RUN pip3 install torch==2.4.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install torch==2.4.0 --index-url https://download.pytorch.org/whl/cpu
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \

--- a/examples/cpp/cart_pole/CMakeLists.txt
+++ b/examples/cpp/cart_pole/CMakeLists.txt
@@ -35,9 +35,15 @@ foreach(tgt ${cart_pole_example_targets})
   target_link_libraries(${tgt} PRIVATE MPI::MPI_CXX)
   target_link_libraries(${tgt} PRIVATE ${YAML_CPP_LIBRARY})
   target_link_libraries(${tgt} PRIVATE environments)
-  target_link_libraries(${tgt} PRIVATE CUDA::cudart)
   target_compile_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${TORCH_CXX_FLAGS}>)
   target_link_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${TORCH_CXX_FLAGS}>)
+  if (TORCHFORT_ENABLE_GPU)
+    target_include_directories(${tgt}
+      PRIVATE
+      ${CUDAToolkit_INCLUDE_DIRS}
+    )
+    target_link_libraries(${tgt} PRIVATE CUDA::cudart)
+  endif()
 endforeach()
 
 # installation

--- a/examples/cpp/cart_pole/config.yaml
+++ b/examples/cpp/cart_pole/config.yaml
@@ -14,7 +14,7 @@ algorithm:
     gamma: 0.99
     rho: 0.99
 
-action:
+actor:
   type: space_noise
   parameters:
     a_low: -1.0

--- a/examples/cpp/cart_pole/python/initialize_models.py
+++ b/examples/cpp/cart_pole/python/initialize_models.py
@@ -40,10 +40,13 @@ def main(args):
 
     # set seed
     torch.manual_seed(666)
-    torch.cuda.manual_seed(666)
-    
-    # script model:
-    device = torch.device("cuda:0")
+
+    # CUDA check
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(666)
+        device = torch.device("cuda:0")
+    else:
+        device = torch.device("cpu")
 
     # parameters
     batch_size = 64

--- a/examples/cpp/cart_pole/python/visualize.py
+++ b/examples/cpp/cart_pole/python/visualize.py
@@ -130,11 +130,14 @@ def main(args):
 
     # set seed
     torch.manual_seed(666)
-    torch.cuda.manual_seed(666)
-    
-    # script model:
-    device = torch.device("cuda:0")
 
+    # CUDA check
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(666)
+        device = torch.device("cuda:0")
+    else:
+        device = torch.device("cpu")
+    
     # parameters
     batch_size = 1
 

--- a/examples/fortran/simulation/generate_fcn_model.py
+++ b/examples/fortran/simulation/generate_fcn_model.py
@@ -42,8 +42,11 @@ def main():
   model = Net()
   print("FCN model:", model)
 
-  # Move model to GPU, JIT, and save
-  model.to("cuda")
+  try:
+    # Move model to GPU, JIT, and save
+    model.to("cuda")
+  except:
+    print("PyTorch does not have CUDA support. Saving model on CPU.")
   model_jit = torch.jit.script(model)
   model_jit.save("fcn_torchscript.pt")
 

--- a/src/csrc/include/internal/distributed.h
+++ b/src/csrc/include/internal/distributed.h
@@ -30,9 +30,11 @@
 
 #pragma once
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
-#include <mpi.h>
 #include <nccl.h>
+#endif
+#include <mpi.h>
 
 #include <torch/torch.h>
 
@@ -50,9 +52,11 @@ struct Comm {
   int rank;
   int size;
   MPI_Comm mpi_comm;
+#ifdef ENABLE_GPU
   ncclComm_t nccl_comm = nullptr;
   cudaStream_t stream = nullptr;
   cudaEvent_t event = nullptr;
+#endif
   bool initialized = false;
 
   Comm(MPI_Comm mpi_comm) : mpi_comm(mpi_comm) {};

--- a/src/csrc/include/internal/nvtx.h
+++ b/src/csrc/include/internal/nvtx.h
@@ -32,13 +32,16 @@
 
 #include <string>
 
+#ifdef ENABLE_GPU
 #include <nvtx3/nvToolsExt.h>
+#endif
 
 namespace torchfort {
 
 // Helper class for NVTX ranges
 class nvtx {
 public:
+#ifdef ENABLE_GPU
   static void rangePush(const std::string& range_name) {
     static constexpr int ncolors_ = 8;
     static constexpr int colors_[ncolors_] = {0x3366CC, 0xDC3912, 0xFF9900, 0x109618,
@@ -56,6 +59,10 @@ public:
   }
 
   static void rangePop() { nvtxRangePop(); }
+#else
+  static void rangePush(const std::string& range_name) {}
+  static void rangePop() {}
+#endif
 };
 
 } // namespace torchfort

--- a/src/csrc/include/internal/rl/distributions.h
+++ b/src/csrc/include/internal/rl/distributions.h
@@ -29,8 +29,6 @@
  */
 
 #pragma once
-#include <cuda_runtime.h>
-
 #include <cmath>
 #include <torch/torch.h>
 

--- a/src/csrc/include/internal/rl/noise_actor.h
+++ b/src/csrc/include/internal/rl/noise_actor.h
@@ -31,10 +31,6 @@
 #pragma once
 #include <unordered_map>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/model_pack.h"

--- a/src/csrc/include/internal/rl/off_policy/ddpg.h
+++ b/src/csrc/include/internal/rl/off_policy/ddpg.h
@@ -33,10 +33,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/off_policy/sac.h
+++ b/src/csrc/include/internal/rl/off_policy/sac.h
@@ -33,10 +33,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/off_policy/td3.h
+++ b/src/csrc/include/internal/rl/off_policy/td3.h
@@ -33,10 +33,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/on_policy/ppo.h
+++ b/src/csrc/include/internal/rl/on_policy/ppo.h
@@ -33,10 +33,6 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/policy.h
+++ b/src/csrc/include/internal/rl/policy.h
@@ -33,10 +33,12 @@
 
 #include <yaml-cpp/yaml.h>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
 
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/replay_buffer.h
+++ b/src/csrc/include/internal/rl/replay_buffer.h
@@ -33,10 +33,6 @@
 #include <random>
 #include <tuple>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/rollout_buffer.h
+++ b/src/csrc/include/internal/rl/rollout_buffer.h
@@ -33,10 +33,6 @@
 #include <random>
 #include <tuple>
 
-#include <cuda_runtime.h>
-
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/rl/utils.h
+++ b/src/csrc/include/internal/rl/utils.h
@@ -31,10 +31,12 @@
 #pragma once
 #include <unordered_map>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
 
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include "internal/defines.h"

--- a/src/csrc/include/internal/training.h
+++ b/src/csrc/include/internal/training.h
@@ -32,10 +32,12 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
 
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#endif
 #include <torch/torch.h>
 
 #include <internal/defines.h>
@@ -60,11 +62,13 @@ void inference(const char* name, T* input, size_t input_dim, int64_t* input_shap
 
   auto model = models[name].model.get();
 
+#if ENABLE_GPU
   c10::cuda::OptionalCUDAStreamGuard guard;
   if (model->device().is_cuda()) {
     auto stream = c10::cuda::getStreamFromExternal(ext_stream, model->device().index());
     guard.reset_stream(stream);
   }
+#endif
 
   auto input_tensor_in = get_tensor<L>(input, input_dim, input_shape);
   auto output_tensor_in = get_tensor<L>(output, output_dim, output_shape);
@@ -93,11 +97,13 @@ void train(const char* name, T* input, size_t input_dim, int64_t* input_shape, T
 
   auto model = models[name].model.get();
 
+#ifdef ENABLE_GPU
   c10::cuda::OptionalCUDAStreamGuard guard;
   if (model->device().is_cuda()) {
     auto stream = c10::cuda::getStreamFromExternal(ext_stream, model->device().index());
     guard.reset_stream(stream);
   }
+#endif
 
   auto input_tensor_in = get_tensor<L>(input, input_dim, input_shape);
   auto label_tensor_in = get_tensor<L>(label, label_dim, label_shape);

--- a/src/csrc/include/internal/utils.h
+++ b/src/csrc/include/internal/utils.h
@@ -37,7 +37,9 @@
 #include <c10/core/TensorOptions.h>
 #include <torch/torch.h>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#endif
 
 #include "internal/exceptions.h"
 #include "internal/nvtx.h"

--- a/src/csrc/include/torchfort.h
+++ b/src/csrc/include/torchfort.h
@@ -30,7 +30,11 @@
 
 #pragma once
 #include <stdint.h>
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#else
+typedef void* cudaStream_t;
+#endif
 #include <mpi.h>
 
 #include "torchfort_enums.h"

--- a/src/csrc/include/torchfort_rl.h
+++ b/src/csrc/include/torchfort_rl.h
@@ -30,7 +30,11 @@
 
 #pragma once
 #include "torchfort_enums.h"
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#else
+typedef void* cudaStream_t;
+#endif
 
 #define RL_OFF_POLICY_WANDB_LOG_FUNC(dtype)                                                                            \
   torchfort_result_t torchfort_rl_off_policy_wandb_log_##dtype(const char* name, const char* metric_name,              \

--- a/src/csrc/model_wrapper.cpp
+++ b/src/csrc/model_wrapper.cpp
@@ -33,7 +33,9 @@
 #include <string>
 #include <vector>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#endif
 #include <torch/script.h>
 #include <torch/torch.h>
 

--- a/src/csrc/rl/on_policy/interface.cpp
+++ b/src/csrc/rl/on_policy/interface.cpp
@@ -33,7 +33,9 @@
 #include <memory>
 #include <unordered_map>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#endif
 #include <torch/script.h>
 #include <torch/torch.h>
 #include <yaml-cpp/yaml.h>
@@ -157,6 +159,7 @@ torchfort_result_t torchfort_rl_on_policy_train_step(const char* name, float* p_
                                                       cudaStream_t ext_stream) {
   using namespace torchfort;
 
+#ifdef ENABLE_GPU
   // TODO: we need to figure out what to do if RB and Model streams are different
   c10::cuda::OptionalCUDAStreamGuard guard;
   auto model_device = rl::on_policy::registry[name]->modelDevice();
@@ -164,6 +167,7 @@ torchfort_result_t torchfort_rl_on_policy_train_step(const char* name, float* p_
     auto stream = c10::cuda::getStreamFromExternal(ext_stream, model_device.index());
     guard.reset_stream(stream);
   }
+#endif
 
   try {
     // perform a training step

--- a/src/csrc/torchfort.cpp
+++ b/src/csrc/torchfort.cpp
@@ -36,7 +36,9 @@
 #include <memory>
 #include <unordered_map>
 
+#ifdef ENABLE_GPU
 #include <cuda_runtime.h>
+#endif
 #include <torch/script.h>
 #include <torch/torch.h>
 #include <yaml-cpp/yaml.h>

--- a/src/csrc/utils.cpp
+++ b/src/csrc/utils.cpp
@@ -60,16 +60,19 @@ std::string filename_sanitize(std::string s) {
 
 torch::Device get_device(int device) {
   torch::Device device_torch(torch::kCPU);
+#ifdef ENABLE_GPU
   if (device != TORCHFORT_DEVICE_CPU) {
     device_torch = torch::Device(torch::kCUDA, device);
   }
+#endif
   return device_torch;
 }
 
 torch::Device get_device(const void* ptr) {
+  torch::Device device = torch::Device(torch::kCPU);
+#ifdef ENABLE_GPU
   cudaPointerAttributes attr;
   CHECK_CUDA(cudaPointerGetAttributes(&attr, ptr));
-  torch::Device device = torch::Device(torch::kCPU);
   switch (attr.type) {
     case cudaMemoryTypeHost:
     case cudaMemoryTypeUnregistered:
@@ -78,6 +81,7 @@ torch::Device get_device(const void* ptr) {
     case cudaMemoryTypeDevice:
       device = torch::Device(torch::kCUDA); break;
   }
+#endif
   return device;
 }
 

--- a/src/csrc/utils.cpp
+++ b/src/csrc/utils.cpp
@@ -60,11 +60,13 @@ std::string filename_sanitize(std::string s) {
 
 torch::Device get_device(int device) {
   torch::Device device_torch(torch::kCPU);
-#ifdef ENABLE_GPU
   if (device != TORCHFORT_DEVICE_CPU) {
+#ifdef ENABLE_GPU
     device_torch = torch::Device(torch::kCUDA, device);
-  }
+#else
+    THROW_NOT_SUPPORTED("Attempted to place a model or other component on GPU but TorchFort was build without GPU support.");
 #endif
+  }
   return device_torch;
 }
 

--- a/tests/rl/CMakeLists.txt
+++ b/tests/rl/CMakeLists.txt
@@ -56,10 +56,12 @@ foreach(tgt ${test_targets})
   target_link_libraries(${tgt} PRIVATE ${TORCH_LIBRARIES})
   target_link_libraries(${tgt} PRIVATE ${YAML_CPP_LIBRARY})
   target_link_libraries(${tgt} PRIVATE MPI::MPI_CXX)
-  target_link_libraries(${tgt} PRIVATE CUDA::cudart)
   target_link_libraries(${tgt} PRIVATE GTest::gtest_main)
   target_compile_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${TORCH_CXX_FLAGS}>)
   target_link_options(${tgt} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${TORCH_CXX_FLAGS}>)
+if (TORCHFORT_ENABLE_GPU)
+  target_link_libraries(${tgt} PRIVATE CUDA::cudart)
+endif()
 
   # discover tests: we have an issue with the work dir of gtest so disable that for now
   #gtest_discover_tests(${tgt})


### PR DESCRIPTION
For local experimentation, users may desire to try out TorchFort on a system without CUDA or a GPU available. This PR enables building TorchFort for CPU only (via a new CMake build option `TORCHFORT_ENABLE_GPU`, which can be set to zero to disable GPU support). Refer to [Dockerfile_gnu_cpuonly](https://github.com/NVIDIA/TorchFort/blob/gpu_optional/docker/Dockerfile_gnu_cpuonly) to see an example of building on an Ubuntu system for CPU only.

This PR also includes bumping PyTorch to a more recent version (2.4.0) in the Dockerfiles, as well as a bit of housekeeping work on those files.