### PR TITLE
Save optimizer state to CPU to enable cross-device training restart.

### DIFF
--- a/src/csrc/include/internal/model_pack.h
+++ b/src/csrc/include/internal/model_pack.h
@@ -45,6 +45,7 @@ namespace torchfort {
 struct ModelPack {
   std::shared_ptr<ModelWrapper> model;
   std::shared_ptr<torch::optim::Optimizer> optimizer;
+  std::string optimizer_type;
   std::shared_ptr<BaseLRScheduler> lr_scheduler;
   std::shared_ptr<BaseLoss> loss;
   std::shared_ptr<Comm> comm;

--- a/src/csrc/torchfort.cpp
+++ b/src/csrc/torchfort.cpp
@@ -105,6 +105,7 @@ torchfort_result_t torchfort_create_model(const char* name, const char* config_f
     // Setting up optimizer
     if (config["optimizer"]) {
       models[name].optimizer = get_optimizer(config["optimizer"], models[name].model);
+      models[name].optimizer_type = sanitize(config["optimizer"]["type"].as<std::string>());
     }
 
     // Setting up lr_scheduler


### PR DESCRIPTION
This PR enables reloading training checkpoints on a different device than used initially for training. Previously, the optimizer state tensors were saved on the training device, which caused issues when loading the optimizer on a different device (i.e. training would halt due to state tensors being located on a different device). To work around this issue, the optimizer state tensors are saved/loaded on the CPU, similar to how we treat the model weights. The state tensors are moved to the target training device after loading.