### PR TITLE
Guarding cart pole example against CPU only compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,9 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs DESTINATION ${CMAKE_INSTALL_P
 
 # build examples
 if (TORCHFORT_BUILD_EXAMPLES)
-  add_subdirectory(examples/cpp/cart_pole)
+  if(TORCHFORT_ENABLE_GPU)
+    add_subdirectory(examples/cpp/cart_pole)
+  endif()
   if (TORCHFORT_BUILD_FORTRAN)
     add_subdirectory(examples/fortran/simulation)
   endif()


### PR DESCRIPTION
This MR guards the compilation of the cart pole example against a missing CUDA installation.