### PR TITLE
Add more robust check for MPI_Comm_f2c during build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,15 @@ if (TORCHFORT_BUILD_FORTRAN)
     target_compile_options("${PROJECT_NAME}_fort" PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp>)
   endif()
 
-  if (CMAKE_Fortran_COMPILER MATCHES "ftn")
+  # Test for MPI_Comm_f2c/c2f
+  try_compile(
+    TEST_F2C_RESULT
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_mpi_f2c.f90
+    LINK_LIBRARIES MPI::MPI_Fortran
+  )
+  if (NOT TEST_F2C_RESULT)
+    message(STATUS "Could not link MPI_Comm_f2c in Fortran module. Setting -DMPICH flag during module compilation.")
     target_compile_definitions("${PROJECT_NAME}_fort" PRIVATE MPICH)
   endif()
 

--- a/cmake/test_mpi_f2c.f90
+++ b/cmake/test_mpi_f2c.f90
@@ -1,0 +1,61 @@
+! SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this
+!    list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice,
+!    this list of conditions and the following disclaimer in the documentation
+!    and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its
+!    contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+! FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+! DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+! SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module test_f2c
+  use iso_c_binding
+  implicit none
+
+  type, bind(c) :: MPI_C_Comm
+    integer(c_int64_t) :: comm
+  end type MPI_C_Comm
+
+  type, bind(c) :: MPI_F_Comm
+    integer(c_int) :: comm
+  end type MPI_F_Comm
+
+  interface
+    function MPI_Comm_f2c(fcomm) bind(C,name='MPI_Comm_f2c') result(res)
+      import
+      type(MPI_F_Comm), value :: fcomm
+      type(MPI_C_Comm) :: res
+    end function MPI_Comm_f2c
+  end interface
+end module
+
+program main
+  use mpi
+  use test_f2c
+  implicit none
+
+  type(MPI_F_Comm) :: fcomm
+  type(MPI_C_Comm) :: ccomm
+
+  fcomm%comm = MPI_COMM_WORLD
+
+  ccomm = MPI_Comm_f2c(fcomm)
+end program


### PR DESCRIPTION
In #28, a user reported build problems, one issue being an unresolved link to `MPI_Comm_f2c`, which isn't available in all MPI distributions. Our current check works for Cray MPICH, but we should generalize it to avoid this issue. To handle this, I've brought over my `MPI_Comm_f2c` checking functionality from [cuDecomp](https://github.com/NVIDIA/cuDecomp) in this PR. 