### PR TITLE
fixing CHECK_MPI according to issue #30

### DIFF
--- a/src/csrc/include/internal/defines.h
+++ b/src/csrc/include/internal/defines.h
@@ -68,7 +68,7 @@
   } while (false)
 
 #define CHECK_MPI(call)                                                                                                \
-  {                                                                                                                    \
+  do {                                                                                                                 \
     int err = call;                                                                                                    \
     if (0 != err) {                                                                                                    \
       char error_str[MPI_MAX_ERROR_STRING];                                                                            \
@@ -83,8 +83,7 @@
       }                                                                                                                \
       exit(EXIT_FAILURE);                                                                                              \
     }                                                                                                                  \
-  }                                                                                                                    \
-  while (false)
+  } while (false)
 
 #define BEGIN_MODEL_REGISTRY                                                                                           \
   static std::unordered_map<std::string, std::function<std::shared_ptr<BaseModel>()>> model_registry {


### PR DESCRIPTION
This adds the missing do to the CHECK_MPI macro as and standardizes the format with respect to the other macros.