### PR TITLE
Disambiguate module locations for Fortran simulation example to fix race condition during compilation.

### DIFF
--- a/examples/fortran/simulation/CMakeLists.txt
+++ b/examples/fortran/simulation/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(train
   train.f90
   simulation.f90
 )
+set_target_properties(train PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mod/0 )
 
 add_executable(train_distributed)
 target_sources(train_distributed
@@ -18,6 +19,7 @@ target_sources(train_distributed
   train_distributed.f90
   simulation.f90
 )
+set_target_properties(train_distributed PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mod/1 )
 
 foreach(tgt ${fortran_example_targets})
   target_include_directories(${tgt}


### PR DESCRIPTION
The simulation example in Fortran reuses the `simulation.f90` file and module twice, once for the serial `train` executable and once for the distributed `train_distributed` example. This can cause issues during parallel compilation (`make -j`) where  the module can potentially be overwritten/deleted in a conflicting way between the two targets. This PR adds explicit `Fortran_MODULE_DIRECTORY`properties to the targets to disambiguate them and avoid the issue.