### PR TITLE
adding seeding option

### DIFF
--- a/src/csrc/include/internal/rl/off_policy.h
+++ b/src/csrc/include/internal/rl/off_policy.h
@@ -66,6 +66,7 @@ public:
   virtual void updateReplayBuffer(torch::Tensor, torch::Tensor, torch::Tensor, float, bool) = 0;
   // multi env
   virtual void updateReplayBuffer(torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor) = 0;
+  virtual void setSeed(unsigned int seed) = 0;
   virtual bool isReady() = 0;
 
   // these have to be implemented
@@ -80,6 +81,7 @@ public:
   virtual void loadCheckpoint(const std::string& checkpoint_dir) = 0;
   virtual torch::Device modelDevice() const = 0;
   virtual torch::Device rbDevice() const = 0;
+  virtual int getRank() const =0;
 
 protected:
   virtual std::shared_ptr<ModelState> getSystemState_() = 0;

--- a/src/csrc/include/internal/rl/off_policy/ddpg.h
+++ b/src/csrc/include/internal/rl/off_policy/ddpg.h
@@ -222,6 +222,7 @@ public:
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, float r, bool d);
   // multi env
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d);
+  void setSeed(unsigned int seed);
   bool isReady();
 
   // train step
@@ -243,6 +244,7 @@ public:
   // accessors
   torch::Device modelDevice() const;
   torch::Device rbDevice() const;
+  int getRank() const;
 
 private:
   // we need those accessors for logging

--- a/src/csrc/include/internal/rl/off_policy/sac.h
+++ b/src/csrc/include/internal/rl/off_policy/sac.h
@@ -338,6 +338,7 @@ public:
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, float r, bool d);
   // multi env
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d);
+  void setSeed(unsigned int seed);
   bool isReady();
 
   // train step
@@ -359,6 +360,7 @@ public:
   // accessors
   torch::Device modelDevice() const;
   torch::Device rbDevice() const;
+  int getRank() const;
 
 private:
   // we need those accessors for logging

--- a/src/csrc/include/internal/rl/off_policy/td3.h
+++ b/src/csrc/include/internal/rl/off_policy/td3.h
@@ -263,6 +263,7 @@ public:
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, float r, bool d);
   // multi env
   void updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d);
+  void setSeed(unsigned int seed);
   bool isReady();
 
   // train step
@@ -284,6 +285,7 @@ public:
   // accessors
   torch::Device modelDevice() const;
   torch::Device rbDevice() const;
+  int getRank() const;
 
 private:
   // we need those accessors for logging

--- a/src/csrc/include/internal/rl/on_policy.h
+++ b/src/csrc/include/internal/rl/on_policy.h
@@ -68,6 +68,7 @@ public:
   virtual void updateRolloutBuffer(torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor) = 0;
   // virtual void finalizeRolloutBuffer(float, bool) = 0;
   virtual void resetRolloutBuffer() = 0;
+  virtual void setSeed(unsigned int seed) = 0;
   virtual bool isReady() = 0;
 
   // these have to be implemented

--- a/src/csrc/include/internal/rl/on_policy/ppo.h
+++ b/src/csrc/include/internal/rl/on_policy/ppo.h
@@ -273,6 +273,7 @@ public:
   void updateRolloutBuffer(torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor);
   // void finalizeRolloutBuffer(float, bool);
   void resetRolloutBuffer();
+  void setSeed(unsigned int);
   bool isReady();
 
   // train step

--- a/src/csrc/include/internal/rl/replay_buffer.h
+++ b/src/csrc/include/internal/rl/replay_buffer.h
@@ -75,6 +75,7 @@ public:
   virtual bool isReady() const = 0;
   virtual void reset() = 0;
   virtual size_t getSize() const = 0;
+  virtual void setSeed(unsigned int seed) = 0;
   virtual void printInfo() const = 0;
   virtual void save(const std::string& fname) const = 0;
   virtual void load(const std::string& fname) = 0;
@@ -267,6 +268,10 @@ public:
   }
 
   size_t getSize() const { return buffer_.size(); }
+
+  void setSeed(unsigned int seed) {
+    rng_.seed(seed);
+  }
 
   // save and restore
   void save(const std::string& fname) const {

--- a/src/csrc/include/internal/rl/rollout_buffer.h
+++ b/src/csrc/include/internal/rl/rollout_buffer.h
@@ -77,6 +77,7 @@ public:
   virtual ExtendedBufferEntry getFull(int) = 0;
   virtual bool isReady() const = 0;
   virtual void reset() = 0;
+  virtual void setSeed(unsigned int seed) = 0;
   virtual void printInfo() const = 0;
   virtual void save(const std::string& fname) const = 0;
   virtual void load(const std::string& fname) = 0;
@@ -300,6 +301,10 @@ public:
     last_episode_starts_ = torch::ones({static_cast<int64_t>(n_envs_)}, options);
 
     return;
+  }
+
+  void setSeed(unsigned int seed) {
+    rng_.seed(seed);
   }
 
   void save(const std::string& fname) const {

--- a/src/csrc/rl/off_policy/ddpg.cpp
+++ b/src/csrc/rl/off_policy/ddpg.cpp
@@ -239,6 +239,14 @@ torch::Device DDPGSystem::modelDevice() const { return model_device_; }
 
 torch::Device DDPGSystem::rbDevice() const { return rb_device_; }
 
+int DDPGSystem::getRank() const {
+  if (!system_comm_) {
+    return 0;
+  } else {
+    return system_comm_->rank;
+  }
+}
+
 void DDPGSystem::initSystemComm(MPI_Comm mpi_comm) {
   // Set up distributed communicators for all models
   // system
@@ -367,6 +375,8 @@ void DDPGSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Ten
 
   DDPGSystem::updateReplayBuffer(stensu, atensu, sptensu, rtensu, dtensu);
 }
+
+void DDPGSystem::setSeed(unsigned int seed) { replay_buffer_->setSeed(seed); }
 
 bool DDPGSystem::isReady() { return (replay_buffer_->isReady()); }
 

--- a/src/csrc/rl/off_policy/interface.cpp
+++ b/src/csrc/rl/off_policy/interface.cpp
@@ -121,6 +121,9 @@ torchfort_result_t torchfort_rl_off_policy_create_distributed_system(const char*
   try {
     torchfort_rl_off_policy_create_system(name, config_fname, model_device, rb_device);
     rl::off_policy::registry[sanitize(name)]->initSystemComm(mpi_comm);
+    // set the RNG for the rollout buffer
+    unsigned int seed = 5489u + static_cast<unsigned int>(rl::off_policy::registry[sanitize(name)]->getRank());
+    rl::off_policy::registry[sanitize(name)]->setSeed(seed);
   } catch (const BaseException& e) {
     std::cerr << e.what();
     return e.getResult();

--- a/src/csrc/rl/off_policy/sac.cpp
+++ b/src/csrc/rl/off_policy/sac.cpp
@@ -265,6 +265,14 @@ torch::Device SACSystem::modelDevice() const { return model_device_; }
 
 torch::Device SACSystem::rbDevice() const { return rb_device_; }
 
+int SACSystem::getRank() const	{
+  if (!system_comm_) {
+    return 0;
+  } else {
+    return system_comm_->rank;
+  }
+}
+
 void SACSystem::initSystemComm(MPI_Comm mpi_comm) {
   // Set up distributed communicators for all models
   // system
@@ -512,6 +520,8 @@ void SACSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tens
 
   SACSystem::updateReplayBuffer(stensu, atensu, sptensu, rtensu, dtensu);
 }
+
+void SACSystem::setSeed(unsigned int seed) { replay_buffer_->setSeed(seed); }
 
 bool SACSystem::isReady() { return (replay_buffer_->isReady()); }
 

--- a/src/csrc/rl/off_policy/td3.cpp
+++ b/src/csrc/rl/off_policy/td3.cpp
@@ -253,6 +253,14 @@ torch::Device TD3System::modelDevice() const { return model_device_; }
 
 torch::Device TD3System::rbDevice() const { return rb_device_; }
 
+int TD3System::getRank() const	{
+  if (!system_comm_) {
+    return 0;
+  } else {
+    return system_comm_->rank;
+  }
+}
+
 void TD3System::initSystemComm(MPI_Comm mpi_comm) {
   // Set up distributed communicators for all models
   // system
@@ -413,6 +421,8 @@ void TD3System::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tens
 
   TD3System::updateReplayBuffer(stensu, atensu, sptensu, rtensu, dtensu);
 }
+
+void TD3System::setSeed(unsigned int seed) { replay_buffer_->setSeed(seed); }
 
 bool TD3System::isReady() { return (replay_buffer_->isReady()); }
 

--- a/src/csrc/rl/on_policy/ppo.cpp
+++ b/src/csrc/rl/on_policy/ppo.cpp
@@ -344,6 +344,8 @@ void PPOSystem::updateRolloutBuffer(torch::Tensor stens, torch::Tensor atens, to
 
 void PPOSystem::resetRolloutBuffer() { rollout_buffer_->reset(); }
 
+void PPOSystem::setSeed(unsigned int seed) { rollout_buffer_->setSeed(seed); }
+
 bool PPOSystem::isReady() { return (rollout_buffer_->isReady()); }
 
 std::shared_ptr<ModelState> PPOSystem::getSystemState_() { return system_state_; }


### PR DESCRIPTION
This MR adds a feature which will initialize the rollout and replay buffer seeds on different ranks differently, to avoid sampling the same samples in cases where those buffers are synchronized between ranks. Currently, this is done automatically but upon request, I could also expose that function to the user.