### PR TITLE
Add tensor continuity checks in allreduce and broadcast methods.

### DIFF
--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -113,6 +113,11 @@ void Comm::finalize() {
 }
 
 void Comm::allreduce(torch::Tensor& tensor, bool average) const {
+
+  if (!tensor.is_contiguous()) {
+    THROW_NOT_SUPPORTED("allreduce method does not support non-contiguous tensors.");
+  }
+
 #ifdef ENABLE_GPU
   if (tensor.device().type() == torch::kCUDA) {
     auto torch_stream = c10::cuda::getCurrentCUDAStream().stream();
@@ -164,6 +169,9 @@ void Comm::allreduce(std::vector<torch::Tensor>& tensors, bool average) const {
 #endif
 
   for (auto& t : tensors) {
+    if (!t.is_contiguous()) {
+      THROW_NOT_SUPPORTED("allreduce method does not support non-contiguous tensors.");
+    }
     allreduce(t, average);
   }
 

--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -198,8 +198,11 @@ void Comm::allreduce(float& val, bool average) const {
 }
 
 void Comm::broadcast(torch::Tensor& tensor, int root) const {
-  auto count = torch::numel(tensor);
+  if (!tensor.is_contiguous()) {
+    THROW_NOT_SUPPORTED("broadcast method does not support non-contiguous tensors.");
+  }
 
+  auto count = torch::numel(tensor);
 #ifdef ENABLE_GPU
   if (tensor.device().type() == torch::kCUDA) {
     // Use NCCL for GPU tensors


### PR DESCRIPTION
This PR adds checks for tensor continuity in the  `Comm::allreduce` and `Comm::broadcast` methods in `distributed.cpp`. While we fully control the use of these methods internally in TorchFort and do not call them on non-contiguous tensors, it has come to our attention that others may use this code as the basis for their own projects. Adding these checks to better constrain what inputs these methods support. 

Addresses #39.