### PR TITLE
Better handling of g++ compiler requirement in CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,7 @@ endif()
 
 project(torchfort LANGUAGES ${LANGS})
 
-message(STATUS "${CMAKE_CXX_COMPILER_ID}")
-if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
   # __rdtsc() in torch not supported by nvc++. Use g++ for CXX files.
   message(FATAL_ERROR "TorchFort does not support compilation of C++ files with nvc++. "
                       "Set CMAKE_CXX_COMPILER to g++ to proceed.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,22 @@ if (NOT TORCHFORT_YAML_CPP_ROOT)
   message(FATAL_ERROR "Please set TORCHFORT_YAML_CPP_ROOT to yaml-cpp installation directory.")
 endif()
 
-# __rdtsc() in torch not supported by nvc++. Use g++ for CXX files.
-set(CMAKE_CXX_COMPILER "g++")
 
 if (TORCHFORT_BUILD_FORTRAN)
   set(LANGS Fortran CXX)
 else()
   set(LANGS CXX)
 endif()
+
 project(torchfort LANGUAGES ${LANGS})
+
+message(STATUS "${CMAKE_CXX_COMPILER_ID}")
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # __rdtsc() in torch not supported by nvc++. Use g++ for CXX files.
+  message(FATAL_ERROR "TorchFort does not support compilation of C++ files with nvc++. "
+                      "Set CMAKE_CXX_COMPILER to g++ to proceed.")
+endif()
+
 
 # unit testing with gtest
 if (TORCHFORT_BUILD_TESTS)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,7 @@ COPY . /torchfort
 RUN cd /torchfort && mkdir build && cd build && \
     CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.1/cuda \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/torchfort \
+    -DCMAKE_CXX_COMPILER=`which g++` \
     -DTORCHFORT_YAML_CPP_ROOT=/opt/yaml-cpp \
     -DTORCHFORT_NCCL_ROOT=/opt/nccl/build \
     -DTORCHFORT_BUILD_EXAMPLES=1 \


### PR DESCRIPTION
Fixes #43.

In the past, to avoid compilation issues with `nvc++` compilers, we explicitly set `CMAKE_CXX_COMPILER` to `g++` in `CMakeLists.txt`. As discovered in that issue, this can be problematic if a user is attempting to specify a alternative `g++` compiler (either on the command line via `CMAKE_CXX_COMPILER` or environment variable `CXX`), where this explicit setting forces builds to use the default `g++` executable and ignore the user options.

This PR removes this explicit override of `CMAKE_CXX_COMPILER` and instead will error out only if a user tries to build the C++ components of TorchFort with `nvc++` (with a warning message suggesting the use of `g++`). 