### PR TITLE
Add support for gradient accumulation

### DIFF
--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -55,6 +55,10 @@ The block in the configuration file defining optimizer properties takes the foll
     type: <optimizer_type>
     parameters:
       <option> = <value>
+    general:
+      <option> = value
+
+The :code:`general` block is optional.
 
 The following table lists the available optimizer types:
 
@@ -67,7 +71,7 @@ The following table lists the available optimizer types:
 +----------------+---------------------------------------+
 
 
-The following table lists the available options by optimizer type:
+The following table lists the available parameter options by optimizer type:
 
 +----------------+-------------------+-----------+-------------------------------------------------------------------------------------------+
 | Optimizer Type | Option            | Data Type | Description                                                                               |
@@ -94,6 +98,14 @@ The following table lists the available options by optimizer type:
 +                +-------------------+-----------+-------------------------------------------------------------------------------------------+
 |                | ``amsgrad``       | boolean   | whether to use AMSGrad variant (default = ``false``)                                      |
 +----------------+-------------------+-----------+-------------------------------------------------------------------------------------------+
+
+The following table lists the available general options:
+
++------------------------------+-----------+------------------------------------------------------------------------------------------------+
+| Option                       | Data Type | Description                                                                                    |
++==============================+===========+================================================================================================+
+| ``grad_accumulation_steps``  | integer   | number of training steps to accumulate gradients between optimizer steps  (default = ``1``)    |
++------------------------------+-----------+------------------------------------------------------------------------------------------------+
 
 .. _lr_schedule_properties-ref:
 

--- a/src/csrc/include/internal/model_pack.h
+++ b/src/csrc/include/internal/model_pack.h
@@ -49,6 +49,7 @@ struct ModelPack {
   std::shared_ptr<BaseLoss> loss;
   std::shared_ptr<Comm> comm;
   std::shared_ptr<ModelState> state;
+  int grad_accumulation_steps = 1;
 };
 
 void save_model_pack(const ModelPack& model_pack, const std::string& fname, bool save_optimizer = true);

--- a/src/csrc/include/internal/model_state.h
+++ b/src/csrc/include/internal/model_state.h
@@ -40,6 +40,7 @@ namespace torchfort {
 struct ModelState {
   int64_t step_train;
   int64_t step_inference;
+  int64_t step_train_current; // training step of current run (ignoring restarted state)
   torch::Device device = torch::Device(torch::kCPU);
 
   // General option settings

--- a/src/csrc/include/internal/rl/off_policy/sac.h
+++ b/src/csrc/include/internal/rl/off_policy/sac.h
@@ -286,8 +286,8 @@ void train_sac(const PolicyPack& p_model, const std::vector<ModelPack>& q_models
     state->step_train++;
     state->step_train_current++;
   }
-  auto q_model = q_models[0]
-  state = q_models.state;
+  auto q_model = q_models[0];
+  state = q_models[0].state;
   if (state->report_frequency > 0 && state->step_train % state->report_frequency == 0) {
     std::stringstream os;
     os << "model: critic,";

--- a/src/csrc/include/internal/rl/policy.h
+++ b/src/csrc/include/internal/rl/policy.h
@@ -86,6 +86,7 @@ struct PolicyPack {
   std::shared_ptr<BaseLRScheduler> lr_scheduler;
   std::shared_ptr<Comm> comm;
   std::shared_ptr<ModelState> state;
+  int grad_accumulation_steps = 1;
 };
 
 class GaussianPolicy : public Policy, public std::enable_shared_from_this<Policy> {
@@ -146,6 +147,7 @@ struct ACPolicyPack {
   std::shared_ptr<BaseLRScheduler> lr_scheduler;
   std::shared_ptr<Comm> comm;
   std::shared_ptr<ModelState> state;
+  int grad_accumulation_steps = 1;
 };
 
 class GaussianACPolicy : public ACPolicy, public std::enable_shared_from_this<ACPolicy> {

--- a/src/csrc/torchfort.cpp
+++ b/src/csrc/torchfort.cpp
@@ -108,6 +108,17 @@ torchfort_result_t torchfort_create_model(const char* name, const char* config_f
     // Setting up optimizer
     if (config["optimizer"]) {
       models[name].optimizer = get_optimizer(config["optimizer"], models[name].model);
+
+      if (config["optimizer"]["general"]) {
+        auto params = get_params(config["optimizer"]["general"]);
+        std::set<std::string> supported_params{"grad_accumulation_steps"};
+        check_params(supported_params, params.keys());
+        try {
+          models[name].grad_accumulation_steps = params.get_param<int>("grad_accumulation_steps")[0];
+        } catch (std::out_of_range) {
+          // default
+        }
+      }
     }
 
     // Setting up lr_scheduler

--- a/src/csrc/training.cpp
+++ b/src/csrc/training.cpp
@@ -136,8 +136,6 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
   auto loss =
       models[name].loss->forward(results, labels->tensors, (extra_loss_args) ? extra_loss_args->tensors : std::vector<torch::Tensor>());
 
-  if (models[name].grad_accumulation_steps > 1) loss /= models[name].grad_accumulation_steps;
-
   // extract loss
   *loss_val = loss.item<float>();
 

--- a/src/csrc/training.cpp
+++ b/src/csrc/training.cpp
@@ -66,7 +66,7 @@ void inference_multiarg(const char* name, torchfort_tensor_list_t inputs_in, tor
 
   torch::NoGradGuard no_grad;
 
-  auto model = models[name].model.get();
+  auto model = models[name].model;
 
 #if ENABLE_GPU
   c10::cuda::OptionalCUDAStreamGuard guard;
@@ -114,7 +114,7 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
     THROW_INVALID_USAGE("Training requires a loss function, but loss block was missing in configuration file.");
   }
 
-  auto model = models[name].model.get();
+  auto model = models[name].model;
 
 #ifdef ENABLE_GPU
   c10::cuda::OptionalCUDAStreamGuard guard;
@@ -128,8 +128,8 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
   labels->to(model->device());
 
   model->train();
-  auto opt = models[name].optimizer.get();
-  auto state = models[name].state.get();
+  auto opt = models[name].optimizer;
+  auto state = models[name].state;
 
   // fwd pass
   auto results = model->forward(inputs->tensors);

--- a/tests/supervised/CMakeLists.txt
+++ b/tests/supervised/CMakeLists.txt
@@ -58,6 +58,7 @@ install(
 # copy files
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/mlp.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/mlp2.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/mlp2_gradacc.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/missing_opt.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/missing_loss.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/configs/torchscript.yaml DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/tests/supervised/configs)

--- a/tests/supervised/configs/mlp2_gradacc.yaml
+++ b/tests/supervised/configs/mlp2_gradacc.yaml
@@ -1,0 +1,13 @@
+model:
+  type: mlp
+  parameters:
+    dropout: 0.0
+    layer_sizes: [10, 10, 10]
+
+loss:
+  type: MSE
+
+optimizer:
+  type: adam
+  general:
+    grad_accumulation_steps: 4


### PR DESCRIPTION
This PR adds support for gradient accumulation, which can be used to increase the effective batch size during training (and reduce the amount of gradient allreduce communication during distributed training). The implementation does not perform any additional loss normalization by the number of accumulation steps so users of this functionality will need to take care to modify learning rates appropriately.

The feature is enabled via a new configuration argument `grad_accumulation_steps` within the `optimizer` block:
```
optimizer:
  type: ...
  general:
    grad_accumulation_steps: 4
```