### PR TITLE
adding kLong support to torchfort MPI path

### DIFF
--- a/examples/fortran/graph/train.f90
+++ b/examples/fortran/graph/train.f90
@@ -213,7 +213,7 @@ program train
       endif
       mse = mse + val
     enddo
-    write(6, '(a3,1x,f5.2,1x,a4,2x,e12.4)'), "t:", t + dt, "mse:", mse / (num_nodes - num_boundary_nodes)
+    write(6, '(a3,1x,f5.2,1x,a4,2x,e12.4)') "t:", t + dt, "mse:", mse / (num_nodes - num_boundary_nodes)
 
     write(fidx,'(i7.7)') i
     ! Write ground truth

--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -120,6 +120,11 @@ void Comm::allreduce(torch::Tensor& tensor, bool average) const {
     THROW_NOT_SUPPORTED("allreduce method does not support non-contiguous tensors.");
   }
 
+  auto dtype = tensor.dtype();
+  if ((dtype == torch::kLong) && average) {
+      THROW_NOT_SUPPORTED("allreduce method for integer-valued tensors does not support averaging.");
+  }
+
 #ifdef ENABLE_GPU
   if (tensor.device().type() == torch::kCUDA) {
     auto torch_stream = c10::cuda::getCurrentCUDAStream().stream();

--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -48,6 +48,9 @@ static MPI_Datatype get_mpi_dtype(torch::Tensor tensor) {
     return MPI_FLOAT;
   } else if (dtype == torch::kFloat64) {
     return MPI_DOUBLE;
+  } else if (dtype == torch::kLong) {
+    return MPI_INT64_T;
+  }
   } else {
     THROW_INVALID_USAGE("Unsupported dtype encountered.");
   }

--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -50,7 +50,6 @@ static MPI_Datatype get_mpi_dtype(torch::Tensor tensor) {
     return MPI_DOUBLE;
   } else if (dtype == torch::kLong) {
     return MPI_INT64_T;
-  }
   } else {
     THROW_INVALID_USAGE("Unsupported dtype encountered.");
   }


### PR DESCRIPTION
This adds kLong datatype support to torchfort MPI wrappers