### PR TITLE
Add missing ENABLE_GPU define to cart pole example build.

### DIFF
--- a/examples/cpp/cart_pole/CMakeLists.txt
+++ b/examples/cpp/cart_pole/CMakeLists.txt
@@ -43,6 +43,7 @@ foreach(tgt ${cart_pole_example_targets})
       ${CUDAToolkit_INCLUDE_DIRS}
     )
     target_link_libraries(${tgt} PRIVATE CUDA::cudart)
+    target_compile_definitions(${tgt} PRIVATE ENABLE_GPU)
   endif()
 endforeach()
 


### PR DESCRIPTION
As reported in #61, the cart pole example does not correctly have `ENABLE_GPU` defined when building, meaning it always runs on CPU. This PR addresses that problem.