### PR TITLE
Add missing calls to move loss module and extra_loss_args to model device.

### DIFF
--- a/src/csrc/torchfort.cpp
+++ b/src/csrc/torchfort.cpp
@@ -103,6 +103,7 @@ torchfort_result_t torchfort_create_model(const char* name, const char* config_f
     // Setting up loss
     if (config["loss"]) {
       models[name].loss = get_loss(config["loss"]);
+      models[name].loss->to(get_device(device));
     }
 
     // Setting up optimizer

--- a/src/csrc/training.cpp
+++ b/src/csrc/training.cpp
@@ -126,6 +126,7 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
 
   inputs->to(model->device());
   labels->to(model->device());
+  if (extra_loss_args) extra_loss_args->to(model->device());
 
   model->train();
   auto opt = models[name].optimizer;


### PR DESCRIPTION
As reported in #61, there is an issue where the `extra_loss_args` argument is not appropriately transferred to the model device. This impacts cases using custom loss functions where the user-provided `extra_loss_args` buffer is not already on the same device as the model. 

This PR adds the missing call to move the `extra_loss_args` to the model device during training. It also adds a call to move the loss module to the model device on initialization to handle possible custom loss functions with parameters. 