### PR TITLE
Removing HDF5 dependency from examples to simplify builds. 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,25 +38,11 @@ RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
     make -j$(nproc) && make install
 ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
 
-# Install HDF5
-RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_3.tar.gz && \
-    tar xzf hdf5-1_14_3.tar.gz && \
-    cd hdf5-hdf5-1_14_3 && \
-    CC=mpicc FC=mpifort FCFLAGS=-fPIC CFLAGS=-fPIC \
-    ./configure --enable-parallel \
-                --enable-fortran \
-                --prefix=/opt/hdf5 && \
-    make -j$(nproc) install && \
-    cd .. && \
-    rm -rf hdf5-hdf5-1_14_3 hdf5-1_14_3.tar.gz
-ENV LD_LIBRARY_PATH /opt/hdf5/lib:$LD_LIBRARY_PATH
-
 # Install additional Python dependencies
-RUN pip3 install wandb ruamel-yaml h5py matplotlib pygame moviepy
+RUN pip3 install wandb ruamel-yaml matplotlib pygame moviepy
 
 # Install TorchFort
 ENV FC=nvfortran
-ENV HDF5_ROOT=/opt/hdf5
 COPY . /torchfort
 RUN cd /torchfort && mkdir build && cd build && \
     CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/25.3/cuda \

--- a/docker/Dockerfile_gnu
+++ b/docker/Dockerfile_gnu
@@ -50,25 +50,11 @@ RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
     make -j$(nproc) && make install
 ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
 
-# Install HDF5
-RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_3.tar.gz && \
-    tar xzf hdf5-1_14_3.tar.gz && \
-    cd hdf5-hdf5-1_14_3 && \
-    CC=mpicc FC=mpifort \
-    ./configure --enable-parallel \
-                --enable-fortran \
-                --prefix=/opt/hdf5 && \
-    make -j$(nproc) install && \
-    cd .. && \
-    rm -rf hdf5-hdf5-1_14_3 hdf5-1_14_3.tar.gz
-ENV LD_LIBRARY_PATH /opt/hdf5/lib:$LD_LIBRARY_PATH
-
 # Install additional Python dependencies
-RUN pip3 install wandb ruamel-yaml h5py matplotlib pygame moviepy
+RUN pip3 install wandb ruamel-yaml matplotlib pygame moviepy
 
 # Install TorchFort
 ENV FC=gfortran
-ENV HDF5_ROOT=/opt/hdf5
 COPY . /torchfort
 RUN cd /torchfort && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/torchfort \

--- a/docker/Dockerfile_gnu_cpuonly
+++ b/docker/Dockerfile_gnu_cpuonly
@@ -39,25 +39,11 @@ RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
     make -j$(nproc) && make install
 ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
 
-# Install HDF5
-RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_3.tar.gz && \
-    tar xzf hdf5-1_14_3.tar.gz && \
-    cd hdf5-hdf5-1_14_3 && \
-    CC=mpicc FC=mpifort \
-    ./configure --enable-parallel \
-                --enable-fortran \
-                --prefix=/opt/hdf5 && \
-    make -j$(nproc) install && \
-    cd .. && \
-    rm -rf hdf5-hdf5-1_14_3 hdf5-1_14_3.tar.gz
-ENV LD_LIBRARY_PATH /opt/hdf5/lib:$LD_LIBRARY_PATH
-
 # Install additional Python dependencies
-RUN pip3 install wandb ruamel-yaml h5py matplotlib pygame moviepy
+RUN pip3 install wandb ruamel-yaml matplotlib pygame moviepy
 
 # Install TorchFort without GPU support
 ENV FC=gfortran
-ENV HDF5_ROOT=/opt/hdf5
 COPY . /torchfort
 RUN cd /torchfort && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/torchfort \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,6 @@ For a native installation TorchFort provides a `CMakeList.txt <https://github.co
   - ``yaml-cpp`` from https://github.com/jbeder/yaml-cpp.git
   - MPI
   - NVIDIA Collective Communication Library (``NCCL``)
-  - ``HDF5``
   - the Python modules specified in `requirements.txt <https://github.com/NVIDIA/TorchFort/blob/master/requirements.txt>`_
   - GNU or `NVHPC <https://developer.nvidia.com/hpc-sdk>`_ compilers. NVHPC compilers are **required** if CUDA Fortran device array support is desired.
 

--- a/examples/fortran/graph/CMakeLists.txt
+++ b/examples/fortran/graph/CMakeLists.txt
@@ -15,7 +15,6 @@ foreach(tgt ${fortran_example_targets})
     PRIVATE
     ${CMAKE_BINARY_DIR}/include
     ${MPI_Fortran_INCLUDE_DIRS}
-    ${HDF5_Fortran_INCLUDE_DIRS}
   )
   target_link_libraries(${tgt} PRIVATE MPI::MPI_Fortran)
   target_link_libraries(${tgt} PRIVATE "${PROJECT_NAME}_fort")

--- a/examples/fortran/graph/visualize.py
+++ b/examples/fortran/graph/visualize.py
@@ -59,11 +59,17 @@ def main(args):
     ax2.set_ylabel(r"$y$")
 
     c = ax1.tricontourf(triangulation, np.loadtxt(reffiles[0]), levels=np.linspace(-0.1, 1.0, 15))
-    artists += c.collections
+    try:
+      artists += c.collections
+    except:
+      artists.append(c)
     c = ax1.triplot(triangulation, linewidth=0.3, color='black')
     artists.append(c)
     c = ax2.tricontourf(triangulation, np.loadtxt(predfiles[0]), levels=np.linspace(-0.1, 1.0, 15))
-    artists += c.collections
+    try:
+      artists += c.collections
+    except:
+      artists.append(c)
     c = ax2.triplot(triangulation, linewidth=0.3, color='black')
     artists.append(c)
 
@@ -79,11 +85,17 @@ def main(args):
         artists.clear()
 
         c = ax1.tricontourf(triangulation, np.loadtxt(reffiles[i]), levels=np.linspace(-0.1, 1.0, 15))
-        artists += c.collections
+        try:
+          artists += c.collections
+        except:
+          artists.append(c)
         c = ax1.triplot(triangulation, linewidth=0.3, color='black')
         artists.append(c)
         c = ax2.tricontourf(triangulation, np.loadtxt(predfiles[i]), levels=np.linspace(-0.1, 1.0, 15))
-        artists += c.collections
+        try:
+          artists += c.collections
+        except:
+          artists.append(c)
         c = ax2.triplot(triangulation, linewidth=0.3, color='black')
         artists.append(c)
 

--- a/examples/fortran/simulation/CMakeLists.txt
+++ b/examples/fortran/simulation/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(HDF5 COMPONENTS Fortran REQUIRED)
 
 set(fortran_example_targets
   train
@@ -26,10 +25,8 @@ foreach(tgt ${fortran_example_targets})
     PRIVATE
     ${CMAKE_BINARY_DIR}/include
     ${MPI_Fortran_INCLUDE_DIRS}
-    ${HDF5_Fortran_INCLUDE_DIRS}
   )
   target_link_libraries(${tgt} PRIVATE MPI::MPI_Fortran)
-  target_link_libraries(${tgt} PRIVATE hdf5::hdf5_fortran)
   target_link_libraries(${tgt} PRIVATE "${PROJECT_NAME}_fort")
   target_link_libraries(${tgt} PRIVATE ${PROJECT_NAME})
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")

--- a/examples/fortran/simulation/README.md
+++ b/examples/fortran/simulation/README.md
@@ -70,12 +70,12 @@ $ ./train --configfile config_mlp_native.yaml
 ```
 
 The training will proceed for 100,000 steps, printing information on the loss every 100 iterations. This is followed by validation testing of the trained
-model for 1,000 steps, with model input, target output (label), and predicted output fields writted to HDF5 files every 10 steps.
+model for 1,000 steps, with model input, target output (label), and predicted output fields written to text files every 10 steps.
 
 To visualize the output of the trained model, we've provided a `visualize.py` Python script to load the validation output samples and produce
 a short video of the results. An example command to run this script is:
 ```
-$ python visualize.py --input_path <path to directory containing validation HDF files> --output_path <path to directory to write output video>
+$ python visualize.py --input_path <path to directory containing validation text files> --output_path <path to directory to write output video>
 ```
 
 The resulting video for the trained MLP should look like this:

--- a/examples/fortran/simulation/train.f90
+++ b/examples/fortran/simulation/train.f90
@@ -41,7 +41,7 @@ subroutine print_help_message
   "\t--nval_steps\n" // &
   "\t\tNumber of validation steps to run. (default: 1000) \n" // &
   "\t--val_write_freq\n" // &
-  "\t\tFrequency to write validation HDF5 files. (default: 10) \n" // &
+  "\t\tFrequency to write validation sample files. (default: 10) \n" // &
   "\t--checkpoint_dir\n" // &
   "\t\tCheckpoint directory to load. (default: don't load checkpoint) \n" // &
   "\t--output_model_name\n" // &
@@ -269,11 +269,11 @@ program train
     if (mod(i-1, val_write_freq) == 0) then
       print*, "writing validation sample:", i, "mse:", mse
       write(idx,'(i7.7)') i
-      filename = 'input_'//idx//'.h5'
+      filename = 'input_'//idx//'.txt'
       call write_sample(input(:,:,1,1), filename)
-      filename = 'label_'//idx//'.h5'
+      filename = 'label_'//idx//'.txt'
       call write_sample(label(:,:,1,1), filename)
-      filename = 'output_'//idx//'.h5'
+      filename = 'output_'//idx//'.txt'
       call write_sample(output(:,:,1,1), filename)
     endif
   end do

--- a/examples/fortran/simulation/train_distributed.f90
+++ b/examples/fortran/simulation/train_distributed.f90
@@ -41,7 +41,7 @@ subroutine print_help_message
   "\t--nval_steps\n" // &
   "\t\tNumber of validation steps to run. (default: 1000) \n" // &
   "\t--val_write_freq\n" // &
-  "\t\tFrequency to write validation HDF5 files. (default: 10) \n" // &
+  "\t\tFrequency to write validation sample files. (default: 10) \n" // &
   "\t--checkpoint_dir\n" // &
   "\t\tCheckpoint directory to load. (default: don't load checkpoint) \n" // &
   "\t--output_model_name\n" // &
@@ -341,11 +341,11 @@ program train_distributed
     if (rank == 0 .and. mod(i-1, val_write_freq) == 0) then
       print*, "writing validation sample:", i, "mse:", mse
       write(idx,'(i7.7)') i
-      filename = 'input_'//idx//'.h5'
+      filename = 'input_'//idx//'.txt'
       call write_sample(input(:,:,1,1), filename)
-      filename = 'label_'//idx//'.h5'
+      filename = 'label_'//idx//'.txt'
       call write_sample(label(:,:,1,1), filename)
-      filename = 'output_'//idx//'.h5'
+      filename = 'output_'//idx//'.txt'
       call write_sample(output(:,:,1,1), filename)
     endif
   end do

--- a/examples/fortran/simulation/visualize.py
+++ b/examples/fortran/simulation/visualize.py
@@ -28,7 +28,6 @@
 
 import argparse as ap
 import glob
-import h5py as h5
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation, PillowWriter
 import numpy as np
@@ -59,21 +58,27 @@ def main(args):
     ax4.set_title(r"1D sample along dotted line")
     ax4.set_xlabel(r"$x$")
 
-    with h5.File(infiles[0], 'r') as f:
-        idata = f["data"][...]
-    with h5.File(labelfiles[0], 'r') as f:
-        ldata = f["data"][...]
-    with h5.File(outfiles[0], 'r') as f:
-        odata = f["data"][...]
+    idata = np.loadtxt(infiles[0])
+    ldata = np.loadtxt(labelfiles[0])
+    odata = np.loadtxt(outfiles[0])
 
     c = ax1.contourf(idata)
-    artists += c.collections
+    try:
+      artists += c.collections
+    except:
+      artists.append(c)
     c = ax1.hlines(idata.shape[0]//2 + 1, 0, idata.shape[1]-1, colors="black", linestyles="dashed")
     artists.append(c)
     c = ax2.contourf(ldata)
-    artists += c.collections
+    try:
+      artists += c.collections
+    except:
+      artists.append(c)
     c = ax3.contourf(odata)
-    artists += c.collections
+    try:
+      artists += c.collections
+    except:
+      artists.append(c)
     c, = ax4.plot(idata[idata.shape[0]//2 + 1,:], 'k')
     artists.append(c)
     c, = ax4.plot(ldata[idata.shape[0]//2 + 1,:], 'b')
@@ -89,20 +94,26 @@ def main(args):
             c.remove()
         artists.clear()
 
-        with h5.File(infiles[i], 'r') as f:
-            idata = f["data"][...]
-        with h5.File(labelfiles[i], 'r') as f:
-            ldata = f["data"][...]
-        with h5.File(outfiles[i], 'r') as f:
-            odata = f["data"][...]
+        idata = np.loadtxt(infiles[i])
+        ldata = np.loadtxt(labelfiles[i])
+        odata = np.loadtxt(outfiles[i])
         c = ax1.contourf(idata)
-        artists += c.collections
+        try:
+          artists += c.collections
+        except:
+          artists.append(c)
         c = ax1.hlines(idata.shape[0]//2 + 1, 0, idata.shape[1]-1, colors="black", linestyles="dashed")
         artists.append(c)
         c = ax2.contourf(ldata)
-        artists += c.collections
+        try:
+          artists += c.collections
+        except:
+          artists.append(c)
         c = ax3.contourf(odata)
-        artists += c.collections
+        try:
+          artists += c.collections
+        except:
+          artists.append(c)
         c, = ax4.plot(idata[idata.shape[0]//2 + 1,:], 'k')
         artists.append(c)
         c, = ax4.plot(ldata[idata.shape[0]//2 + 1,:], 'b')
@@ -121,7 +132,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = ap.ArgumentParser()
-    parser.add_argument("--input_path", type=str, help="Directory containing validation hdf5 files", required=True)
+    parser.add_argument("--input_path", type=str, help="Directory containing validation text files", required=True)
     parser.add_argument("--output_path", type=str, help="Directory to store the generated videos", required=True)
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ moviepy
 
 # Supervised learning example visualization related
 matplotlib
-h5py


### PR DESCRIPTION
This PR removes the HDF5 dependency from the Fortran simulation example to simplify/speed up builds. The usage of HDF5 in that example was a bit overkill in the first place, so this is a good improvement.

As part of this PR development, I updated the visualization Python scripts to handle changes in newer matplotlib versions.