### PR TITLE
Add basic build/test and format check workflows to CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,15 @@ jobs:
         include:
           - name: "GPU build (NVHPC SDK 25.7, Ubuntu 22.04)"
             dockerfile: "Dockerfile"
+            free_space: true
             run_tests: false
           - name: "GPU build (GNU, Ubuntu 22.04)"
             dockerfile: "Dockerfile_gnu"
+            free_space: false
             run_tests: false
           - name: "CPU build (GNU, Ubuntu 22.04)"
             dockerfile: "Dockerfile_gnu_cpuonly"
+            free_space: false
             run_tests: true
 
     name: ${{ matrix.name }}
@@ -27,20 +30,21 @@ jobs:
 
     steps:
     - name: "Free disk space" # reference: jlumbroso/free-disk-space
+      if: ${{ matrix.free_space }}
       run: |
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /usr/share/dotnet || true
-        sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
-        sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
-        sudo apt-get clean
+        #sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
+        #sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
+        #sudo apt-get clean
 
     - name: "Checkout code"
       uses: actions/checkout@v4
@@ -53,18 +57,33 @@ jobs:
         docker build -t torchfort -f docker/${{ matrix.dockerfile }} .
 
     - name: "Run tests"
-      if: ${{ matrix.run_tests }} == true
+      if: ${{ matrix.run_tests }}
       run: |
         docker run --rm torchfort bash -c "
           cd /opt/torchfort/bin/tests/general
           python scripts/setup_tests.py
           ./test_losses
+        "
+        docker run --rm torchfort bash -c "
           cd /opt/torchfort/bin/tests/supervised
           python scripts/setup_tests.py
           ./test_checkpoint
+        "
+        docker run --rm torchfort bash -c "
+          cd /opt/torchfort/bin/tests/supervised
+          python scripts/setup_tests.py
           ./test_training
+        "
+        docker run --rm torchfort bash -c "
           cd /opt/torchfort/bin/tests/rl
           ./test_distributions
+        "
+        docker run --rm torchfort bash -c "
+          cd /opt/torchfort/bin/tests/rl
           ./test_replay_buffer
+        "
+        docker run --rm torchfort bash -c "
+          cd /opt/torchfort/bin/tests/rl
           ./test_rollout_buffer
         "
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: "Build docker container"
       run: |
-        docker build -t torchfort -f ${{ matrix.dockerfile }} .
+        docker build -t torchfort -f docker/${{ matrix.dockerfile }} .
 
     - name: "Run tests"
       if: ${{ matrix.run_tests }} == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: "Build"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: "CPU build (GNU, Ubuntu 22.04)"
+            dockerfile: "Dockerfile_gnu_cpuonly"
+
+    name: ${{ matrix.name }}
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: "Build docker container"
+      run: |
+        docker build -t container -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
 name: "Build"
 
 on:
-  #issue_comment:
-  #  types: [created]
-  pull_request:
-    branches: [ master ]
+  issue_comment:
+    types: [created]
 
 jobs:
   build:
-    #if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
     strategy:
       matrix:
         include:
@@ -29,22 +27,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: "Free disk space" # reference: jlumbroso/free-disk-space
+    - name: "Free disk space"
       if: ${{ matrix.free_space }}
       run: |
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /usr/share/dotnet || true
-        #sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
-        #sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
-        #sudo apt-get clean
 
     - name: "Checkout code"
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
 name: "Build"
 
 on:
-  workflow_dispatch:
-  pull_request:
-    branches: [ master ]
+  issue_comment:
+    types: [created]
 
 jobs:
   build:
@@ -14,7 +13,7 @@ jobs:
             dockerfile: "Dockerfile_gnu_cpuonly"
 
     name: ${{ matrix.name }}
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,28 @@
 name: "Build"
 
 on:
-  issue_comment:
-    types: [created]
+  #issue_comment:
+  #  types: [created]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
+    #if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
     strategy:
       matrix:
         include:
+          - name: "GPU build (NVHPC SDK 25.7, Ubuntu 22.04)"
+            dockerfile: "Dockerfile"
+            run_tests: false
+          - name: "GPU build (GNU, Ubuntu 22.04)"
+            dockerfile: "Dockerfile_gnu"
+            run_tests: false
           - name: "CPU build (GNU, Ubuntu 22.04)"
             dockerfile: "Dockerfile_gnu_cpuonly"
+            run_tests: true
 
     name: ${{ matrix.name }}
-    #if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
-    if: github.event.comment.body == '/build'
     runs-on: ubuntu-latest
 
     steps:
@@ -26,4 +34,21 @@ jobs:
 
     - name: "Build docker container"
       run: |
-        docker build -t container -f ${{ matrix.dockerfile }} .
+        docker build -t torchfort -f ${{ matrix.dockerfile }} .
+
+    - name: "Run tests"
+      if: ${{ matrix.run_tests }} == true
+      run: |
+        docker run --rm torchfort bash -c "
+          cd /opt/torchfort/bin/tests/general
+          python scripts/setup_tests.py
+          ./test_losses
+          cd /opt/torchfort/bin/tests/supervised
+          python scripts/setup_tests.py
+          ./test_checkpoint
+          ./test_training
+          cd /opt/torchfort/bin/tests/rl
+          ./test_distributions
+          ./test_replay_buffer
+          ./test_rollout_buffer
+        "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: "Free disk space"
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+
     - name: "Checkout code"
       uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
+    - name: "Set up Docker Buildx"
       uses: docker/setup-buildx-action@v3
 
     - name: "Build docker container"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: "Free disk space"
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: false
+    - name: "Free disk space" # reference: jlumbroso/free-disk-space
+      run: |
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
+        sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
+        sudo apt-get clean
 
     - name: "Checkout code"
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
             dockerfile: "Dockerfile_gnu_cpuonly"
 
     name: ${{ matrix.name }}
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    #if: github.event.issue.pull_request && contains(github.event.comment.body, '/build_and_test')
+    if: github.event.comment.body == '/build'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,56 @@
+name: "Code Format"
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  clang-format:
+    env:
+      CLANG_FORMAT_VERSION: "15"
+
+    runs-on: ubuntu-latest
+    name: "clang-format check"
+
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v4
+
+    - name: "Install dependencies"
+      run: |
+        # Install clang-format
+        sudo apt-get update && sudo apt-get install -y clang-format-${CLANG_FORMAT_VERSION}
+
+        # Print clang-format version information
+        clang-format-${CLANG_FORMAT_VERSION} --version
+
+    - name: "Run clang-format check"
+      run: |
+        # Collect names of files that are not properly formatted
+        filelist=`find src examples -name "*.cpp" -o -name "*.h"`
+        files_to_fix=()
+        for file in $filelist; do
+          if ! clang-format-${CLANG_FORMAT_VERSION} --dry-run --Werror "$file" 2>/dev/null; then
+            files_to_fix+=("$file")
+          fi
+        done
+
+        # If any file is not properly formatted, print diff and exit with error
+        if [ ${#files_to_fix[@]} -gt 0 ]; then
+          # Print the list of files that are not properly formatted
+          echo "FAIL: Some files are not properly formatted. To resolve issues, run:"
+          for file in "${files_to_fix[@]}"; do
+            echo "clang-format-${CLANG_FORMAT_VERSION} -i $file"
+          done
+          echo
+
+          for file in "${files_to_fix[@]}"; do
+            echo "Diff for $file:"
+            bash -c "clang-format-${CLANG_FORMAT_VERSION} $file | diff $file -; exit 0"
+            echo
+          done
+
+          exit 1
+        fi
+
+        echo "PASS: All files are properly formatted."

--- a/src/csrc/distributed.cpp
+++ b/src/csrc/distributed.cpp
@@ -124,7 +124,7 @@ void Comm::allreduce(torch::Tensor& tensor, bool average) const {
 
   auto dtype = tensor.dtype();
   if ((dtype == torch::kLong) && average) {
-      THROW_NOT_SUPPORTED("allreduce method for integer-valued tensors does not support averaging.");
+    THROW_NOT_SUPPORTED("allreduce method for integer-valued tensors does not support averaging.");
   }
 
 #ifdef ENABLE_GPU

--- a/src/csrc/include/internal/base_loss.h
+++ b/src/csrc/include/internal/base_loss.h
@@ -40,8 +40,7 @@
 namespace torchfort {
 
 struct BaseLoss : torch::nn::Module {
-  virtual torch::Tensor forward(const std::vector<torch::Tensor>& inputs,
-                                const std::vector<torch::Tensor>& labels,
+  virtual torch::Tensor forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                                 const std::vector<torch::Tensor>& extra_args) = 0;
   virtual void setup(const ParamMap& params) = 0;
 };

--- a/src/csrc/include/internal/losses.h
+++ b/src/csrc/include/internal/losses.h
@@ -46,8 +46,7 @@ namespace torchfort {
 struct L1Loss : BaseLoss {
   void setup(const ParamMap& params) override;
 
-  torch::Tensor forward(const std::vector<torch::Tensor>& inputs,
-                        const std::vector<torch::Tensor>& labels,
+  torch::Tensor forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                         const std::vector<torch::Tensor>& extra_args) override;
 
   torch::nn::L1Loss module;
@@ -56,8 +55,7 @@ struct L1Loss : BaseLoss {
 struct MSELoss : BaseLoss {
   void setup(const ParamMap& params) override;
 
-  torch::Tensor forward(const std::vector<torch::Tensor>& inputs,
-                        const std::vector<torch::Tensor>& labels,
+  torch::Tensor forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                         const std::vector<torch::Tensor>& extra_args) override;
 
   torch::nn::MSELoss module;
@@ -66,8 +64,7 @@ struct MSELoss : BaseLoss {
 struct TorchscriptLoss : BaseLoss {
   void setup(const ParamMap& params) override;
 
-  torch::Tensor forward(const std::vector<torch::Tensor>& inputs,
-                        const std::vector<torch::Tensor>& labels,
+  torch::Tensor forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                         const std::vector<torch::Tensor>& extra_args) override;
 
   std::shared_ptr<torch::jit::Module> module_jit;

--- a/src/csrc/include/internal/rl/off_policy.h
+++ b/src/csrc/include/internal/rl/off_policy.h
@@ -81,7 +81,7 @@ public:
   virtual void loadCheckpoint(const std::string& checkpoint_dir) = 0;
   virtual torch::Device modelDevice() const = 0;
   virtual torch::Device rbDevice() const = 0;
-  virtual int getRank() const =0;
+  virtual int getRank() const = 0;
 
 protected:
   virtual std::shared_ptr<ModelState> getSystemState_() = 0;
@@ -126,10 +126,9 @@ static void update_replay_buffer(const char* name, T* state_old, T* state_new, s
 
 template <MemoryLayout L, typename T>
 static void update_replay_buffer(const char* name, T* state_old, T* state_new, size_t state_dim, int64_t* state_shape,
-                                 T* action_old, size_t action_dim, int64_t* action_shape,
-				 T* reward, size_t reward_dim, int64_t* reward_shape,
-				 T* final_state, size_t final_state_dim, int64_t* final_state_shape,
-                                 cudaStream_t ext_stream) {
+                                 T* action_old, size_t action_dim, int64_t* action_shape, T* reward, size_t reward_dim,
+                                 int64_t* reward_shape, T* final_state, size_t final_state_dim,
+                                 int64_t* final_state_shape, cudaStream_t ext_stream) {
 
   // no grad
   torch::NoGradGuard no_grad;
@@ -149,13 +148,14 @@ static void update_replay_buffer(const char* name, T* state_old, T* state_new, s
   auto state_new_tensor = get_tensor<L>(state_new, state_dim, state_shape)
                               .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
   auto action_old_tensor = get_tensor<L>(action_old, action_dim, action_shape)
-                              .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+                               .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
   auto reward_tensor = get_tensor<L>(reward, reward_dim, reward_shape)
-                              .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+                           .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
   auto final_state_tensor = get_tensor<L>(final_state, final_state_dim, final_state_shape)
-                              .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true); 
+                                .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
 
-  registry[name]->updateReplayBuffer(state_old_tensor, action_old_tensor, state_new_tensor, reward_tensor, final_state_tensor);
+  registry[name]->updateReplayBuffer(state_old_tensor, action_old_tensor, state_new_tensor, reward_tensor,
+                                     final_state_tensor);
   return;
 }
 
@@ -228,11 +228,10 @@ static void policy_evaluate(const char* name, T* state, size_t state_dim, int64_
 
   // create tensors
   auto state_tensor =
-    get_tensor<L>(state, state_dim, state_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  auto action_tensor =
-    get_tensor<L>(action, action_dim, action_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  auto reward_tensor =
-    get_tensor<L>(reward, reward_dim, reward_shape);
+      get_tensor<L>(state, state_dim, state_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+  auto action_tensor = get_tensor<L>(action, action_dim, action_shape)
+                           .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+  auto reward_tensor = get_tensor<L>(reward, reward_dim, reward_shape);
 
   // fwd pass
   torch::Tensor tmpreward = registry[name]->evaluate(state_tensor, action_tensor).to(reward_tensor.dtype());

--- a/src/csrc/include/internal/rl/off_policy/ddpg.h
+++ b/src/csrc/include/internal/rl/off_policy/ddpg.h
@@ -93,15 +93,15 @@ void train_ddpg(const ModelPack& p_model, const ModelPack& p_model_target, const
   torch::Tensor y_tensor;
   {
     torch::NoGradGuard no_grad;
-    auto q_new_tensor =
-      torch::squeeze(q_model_target.model->forward(std::vector<torch::Tensor>{state_new_tensor, action_new_tensor})[0], 1);
+    auto q_new_tensor = torch::squeeze(
+        q_model_target.model->forward(std::vector<torch::Tensor>{state_new_tensor, action_new_tensor})[0], 1);
     y_tensor = torch::Tensor(reward_tensor + q_new_tensor * gamma * (1. - d_tensor));
   }
 
   // backward and update step
   // compute loss
   torch::Tensor q_old_tensor =
-    torch::squeeze(q_model.model->forward(std::vector<torch::Tensor>{state_old_tensor, action_old_tensor})[0], 1);
+      torch::squeeze(q_model.model->forward(std::vector<torch::Tensor>{state_old_tensor, action_old_tensor})[0], 1);
   torch::Tensor q_loss_tensor = q_loss_func->forward(q_old_tensor, y_tensor);
 
   auto state = q_model.state;
@@ -117,7 +117,7 @@ void train_ddpg(const ModelPack& p_model, const ModelPack& p_model_target, const
       std::vector<torch::Tensor> grads;
       grads.reserve(q_model.model->parameters().size());
       for (const auto& p : q_model.model->parameters()) {
-	grads.push_back(p.grad());
+        grads.push_back(p.grad());
       }
       q_model.comm->allreduce(grads, true);
     }
@@ -155,7 +155,7 @@ void train_ddpg(const ModelPack& p_model, const ModelPack& p_model_target, const
       std::vector<torch::Tensor> grads;
       grads.reserve(p_model.model->parameters().size());
       for (const auto& p : p_model.model->parameters()) {
-	grads.push_back(p.grad());
+        grads.push_back(p.grad());
       }
       p_model.comm->allreduce(grads, true);
     }

--- a/src/csrc/include/internal/rl/on_policy.h
+++ b/src/csrc/include/internal/rl/on_policy.h
@@ -96,10 +96,8 @@ extern std::unordered_map<std::string, std::shared_ptr<RLOnPolicySystem>> regist
 
 // some convenience wrappers
 template <MemoryLayout L, typename T>
-static void update_rollout_buffer(const char* name,
-				  T* state, size_t state_dim, int64_t* state_shape,
-				  T* action, size_t action_dim, int64_t* action_shape,
-				  T reward, bool final_state,
+static void update_rollout_buffer(const char* name, T* state, size_t state_dim, int64_t* state_shape, T* action,
+                                  size_t action_dim, int64_t* action_shape, T reward, bool final_state,
                                   cudaStream_t ext_stream) {
 
   // no grad
@@ -130,12 +128,10 @@ static void update_rollout_buffer(const char* name,
 }
 
 template <MemoryLayout L, typename T>
-static void update_rollout_buffer(const char* name,
-				  T* state, size_t state_dim, int64_t* state_shape,
-				  T* action, size_t action_dim, int64_t* action_shape,
-				  T* reward, size_t reward_dim, int64_t* reward_shape,
-				  T* final_state, size_t final_state_dim, int64_t* final_state_shape,
-                                  cudaStream_t ext_stream) {
+static void update_rollout_buffer(const char* name, T* state, size_t state_dim, int64_t* state_shape, T* action,
+                                  size_t action_dim, int64_t* action_shape, T* reward, size_t reward_dim,
+                                  int64_t* reward_shape, T* final_state, size_t final_state_dim,
+                                  int64_t* final_state_shape, cudaStream_t ext_stream) {
 
   // no grad
   torch::NoGradGuard no_grad;
@@ -159,10 +155,10 @@ static void update_rollout_buffer(const char* name,
       get_tensor<L>(state, state_dim, state_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
   torch::Tensor action_tensor = get_tensor<L>(action, action_dim, action_shape)
                                     .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  torch::Tensor reward_tensor =
-      get_tensor<L>(reward, reward_dim, reward_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  torch::Tensor final_state_tensor =
-      get_tensor<L>(final_state, final_state_dim, final_state_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+  torch::Tensor reward_tensor = get_tensor<L>(reward, reward_dim, reward_shape)
+                                    .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+  torch::Tensor final_state_tensor = get_tensor<L>(final_state, final_state_dim, final_state_shape)
+                                         .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
 
   registry[name]->updateRolloutBuffer(state_tensor, action_tensor, reward_tensor, final_state_tensor);
   return;
@@ -238,10 +234,9 @@ static void policy_evaluate(const char* name, T* state, size_t state_dim, int64_
   // create tensors
   auto state_tensor =
       get_tensor<L>(state, state_dim, state_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  auto action_tensor =
-    get_tensor<L>(action, action_dim, action_shape).to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
-  auto reward_tensor =
-    get_tensor<L>(reward, reward_dim, reward_shape);
+  auto action_tensor = get_tensor<L>(action, action_dim, action_shape)
+                           .to(torch::kFloat32, /* non_blocking = */ false, /* copy = */ true);
+  auto reward_tensor = get_tensor<L>(reward, reward_dim, reward_shape);
 
   // fwd pass
   torch::Tensor tmpreward = registry[name]->evaluate(state_tensor, action_tensor).to(reward_tensor.dtype());

--- a/src/csrc/include/internal/rl/on_policy/ppo.h
+++ b/src/csrc/include/internal/rl/on_policy/ppo.h
@@ -183,17 +183,17 @@ void train_ppo(const ACPolicyPack& pq_model, torch::Tensor state_tensor, torch::
     // of the accumulation procedure
     if ((state->step_train_current + 1) % pq_model.grad_accumulation_steps == 0) {
       if (pq_model.comm) {
-	std::vector<torch::Tensor> grads;
-	grads.reserve(pq_model.model->parameters().size());
-	for (const auto& p : pq_model.model->parameters()) {
-	  grads.push_back(p.grad());
-	}
-	pq_model.comm->allreduce(grads, true);
+        std::vector<torch::Tensor> grads;
+        grads.reserve(pq_model.model->parameters().size());
+        for (const auto& p : pq_model.model->parameters()) {
+          grads.push_back(p.grad());
+        }
+        pq_model.comm->allreduce(grads, true);
       }
-      
+
       // clip
       if (max_grad_norm > 0.) {
-	torch::nn::utils::clip_grad_norm_(pq_model.model->parameters(), max_grad_norm);
+        torch::nn::utils::clip_grad_norm_(pq_model.model->parameters(), max_grad_norm);
       }
 
       // optimizer step

--- a/src/csrc/include/internal/tensor_list.h
+++ b/src/csrc/include/internal/tensor_list.h
@@ -38,22 +38,19 @@
 
 namespace torchfort {
 struct TensorList {
-  template <MemoryLayout L, typename T>
-  void add_tensor(T* data, size_t dim, int64_t* shape) {
+  template <MemoryLayout L, typename T> void add_tensor(T* data, size_t dim, int64_t* shape) {
     auto tensor = get_tensor<L>(data, dim, shape);
     tensors.push_back(tensor);
     tensors_original_.push_back(tensor);
   };
 
   void to(torch::Device device, bool non_blocking = false) {
-    for (auto &t : tensors) {
+    for (auto& t : tensors) {
       t = t.to(device, non_blocking);
     }
   };
 
-  void reset() {
-    tensors = tensors_original_;
-  }
+  void reset() { tensors = tensors_original_; }
 
   std::vector<torch::Tensor> tensors;
   // To preserve references to external data, we store the original tensor objects

--- a/src/csrc/include/torchfort.h
+++ b/src/csrc/include/torchfort.h
@@ -59,7 +59,6 @@ typedef void* cudaStream_t;
  */
 typedef void* torchfort_tensor_list_t;
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -123,14 +122,17 @@ torchfort_result_t torchfort_train_F(const char* name, void* input, size_t input
  * @param[in] name The name of model instance to use, as defined during model creation.
  * @param[in] inputs A tensor list of input tensors.
  * @param[in] labels A tensor list of label tensors.
- * @param[out] loss_val A pointer to a single precision scalar to write the loss value computed during the training iteration.
- * @param[in] extra_loss_args A tensor list of additional tensors to pass into loss computation. Set to nullptr if unused.
+ * @param[out] loss_val A pointer to a single precision scalar to write the loss value computed during the training
+ * iteration.
+ * @param[in] extra_loss_args A tensor list of additional tensors to pass into loss computation. Set to nullptr if
+ * unused.
  * @param[in] stream CUDA stream to enqueue the operation. This argument is ignored if the model is on the CPU.
  *
  * @return \p TORCHFORT_RESULT_SUCCESS on success or error code on failure.
  */
-torchfort_result_t torchfort_train_multiarg(const char* name, torchfort_tensor_list_t inputs, torchfort_tensor_list_t labels,
-                                            float* loss_val, torchfort_tensor_list_t extra_loss_args, cudaStream_t stream);
+torchfort_result_t torchfort_train_multiarg(const char* name, torchfort_tensor_list_t inputs,
+                                            torchfort_tensor_list_t labels, float* loss_val,
+                                            torchfort_tensor_list_t extra_loss_args, cudaStream_t stream);
 
 /**
  * @brief Runs inference on a model using provided input data.
@@ -261,7 +263,6 @@ WANDB_LOG_PROTO(int)
 WANDB_LOG_PROTO(float)
 WANDB_LOG_PROTO(double)
 
-
 // Tensor List Management functions
 /**
  * @brief Creates a TorchFort tensor list.
@@ -298,7 +299,6 @@ torchfort_result_t torchfort_tensor_list_add_tensor(torchfort_tensor_list_t tens
                                                     int64_t* shape, torchfort_datatype_t dtype);
 torchfort_result_t torchfort_tensor_list_add_tensor_F(torchfort_tensor_list_t tensor_list, void* data_ptr, size_t dim,
                                                       int64_t* shape, torchfort_datatype_t dtype);
-
 
 #ifdef __cplusplus
 }

--- a/src/csrc/include/torchfort_rl.h
+++ b/src/csrc/include/torchfort_rl.h
@@ -188,17 +188,18 @@ torchfort_result_t torchfort_rl_off_policy_predict_F(const char* name, void* sta
  *
  * @param[in] name The name of system instance to use, as defined during system creation.
  * @param[in] state A pointer to a memory buffer containing state data.
- * @param[in] state_dim Rank of the state data. Has to equal to state space dimension plus one, where the size of the 
+ * @param[in] state_dim Rank of the state data. Has to equal to state space dimension plus one, where the size of the
  * leading dimension is equal to the batch size.
- * @param[in] state_shape A pointer to an array specifying the shape of the state data. The length has to 
- * be equal to state space dimension plus one, where the size of the leading dimension is equal to the batch size. 
+ * @param[in] state_shape A pointer to an array specifying the shape of the state data. The length has to
+ * be equal to state space dimension plus one, where the size of the leading dimension is equal to the batch size.
  * @param[in] action A pointer to a memory buffer containing action data.
  * @param[in] action_dim Rank of the action data.
  * @param[in] action_shape A pointer to an array specifying the shape of the action data. The length has to
  * be equal to action space dimension plus one, where the size of the leading dimension is equal to the batch size.
  * @param[in, out] reward A pointer to a memory buffer to write reward data.
  * @param[in] reward_dim Rank of the reward data. Has to be equal to 1.
- * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to batch size.
+ * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to
+ * batch size.
  * @param[out] dtype The TorchFort datatype to use for this operation.
  * @param[out] stream CUDA stream to enqueue the operation. This argument is ignored if the model is on the CPU.
  *
@@ -275,29 +276,25 @@ torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_F(const char* na
  * @param[in] reward_dim A Rank of the reward data. Has to be equal to 1.
  * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to 1
  * and the number of entries should be equal to n_env.
- * @param[in] final_state A pointer to a memory buffer with final_state data. Values equal to 1 indicate the end of an episode and values
- * equal to 0 indicate states within an episode. No other values should be passed.
+ * @param[in] final_state A pointer to a memory buffer with final_state data. Values equal to 1 indicate the end of an
+ * episode and values equal to 0 indicate states within an episode. No other values should be passed.
  * @param[in] final_state_dim A Rank of the final_state data. Has to be equal to 1.
- * @param[in] final_state_shape A pointer to an array specifying the shape of the final_state data. Length has to be equal to 1
- * and the number of entries should be equal to n_env.
+ * @param[in] final_state_shape A pointer to an array specifying the shape of the final_state data. Length has to be
+ * equal to 1 and the number of entries should be equal to n_env.
  * @param[out] dtype The TorchFort datatype to use for this operation.
  * @param[out] stream CUDA stream to enqueue the operation. This argument is ignored if the model is on the CPU.
  *
  * @return \p TORCHFORT_RESULT_SUCCESS on success or error code on failure.
  */
-torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi(const char* name, void* state_old,
-								      void* state_new, size_t state_dim, int64_t* state_shape,
-								      void* action_old, size_t action_dim, int64_t* action_shape,
-								      void* reward, size_t reward_dim, int64_t* reward_shape,
-								      void* final_state, size_t final_size_dim, int64_t* final_state_shape,
-								      torchfort_datatype_t dtype, cudaStream_t stream);
+torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi(
+    const char* name, void* state_old, void* state_new, size_t state_dim, int64_t* state_shape, void* action_old,
+    size_t action_dim, int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_size_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t stream);
 
-torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi_F(const char* name, void* state_old,
-									void* state_new, size_t state_dim, int64_t* state_shape,
-									void* action_old, size_t action_dim, int64_t* action_shape,
-									void* reward, size_t reward_dim, int64_t* reward_shape,
-									void* final_state, size_t final_size_dim, int64_t* final_state_shape,
-									torchfort_datatype_t dtype, cudaStream_t stream);
+torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi_F(
+    const char* name, void* state_old, void* state_new, size_t state_dim, int64_t* state_shape, void* action_old,
+    size_t action_dim, int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_size_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t stream);
 
 // RL off-policy checkpoint save and loading functions
 /**
@@ -482,15 +479,16 @@ torchfort_result_t torchfort_rl_on_policy_predict_F(const char* name, void* stat
  * @param[in] name The name of system instance to use, as defined during system creation.
  * @param[in] state A pointer to a memory buffer containing state data.
  * @param[in] state_dim Rank of the state data.
- * @param[in] state_shape A pointer to an array specifying the shape of the state data. The length has to be equal to state space 
- * dimension plus one, where the size of the leading dimension is equal to the batch size.
+ * @param[in] state_shape A pointer to an array specifying the shape of the state data. The length has to be equal to
+ * state space dimension plus one, where the size of the leading dimension is equal to the batch size.
  * @param[in] action A pointer to a memory buffer containing action data.
  * @param[in] action_dim Rank of the action data.
- * @param[in] action_shape A pointer to an array specifying the shape of the action data. The length has to be equal to 
+ * @param[in] action_shape A pointer to an array specifying the shape of the action data. The length has to be equal to
  * action space dimension plus one, where the size of the leading dimension is equal to the batch size.
  * @param[in, out] reward A pointer to a memory buffer to write reward data.
  * @param[in] reward_dim Rank of the reward data. Has to be equal to 1.
- * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to batch size.
+ * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to
+ * batch size.
  * @param[out] dtype The TorchFort datatype to use for this operation.
  * @param[out] stream CUDA stream to enqueue the action prediction operations.
  *
@@ -568,29 +566,25 @@ torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_F(const char* na
  * @param[in] reward_dim A Rank of the reward data. Has to be equal to 1.
  * @param[in] reward_shape A pointer to an array specifying the shape of the reward data. Length has to be equal to 1
  * and the number of entries should be equal to n_env.
- * @param[in] final_state A pointer to a memory buffer with final_state data. Values equal to 1 indicate the end of an episode and values
- * equal to 0 indicate states within an episode. No other values should be passed.
+ * @param[in] final_state A pointer to a memory buffer with final_state data. Values equal to 1 indicate the end of an
+ * episode and values equal to 0 indicate states within an episode. No other values should be passed.
  * @param[in] final_state_dim A Rank of the final_state data. Has to be equal to 1.
- * @param[in] final_state_shape A pointer to an array specifying the shape of the final_state data. Length has to be equal to 1
- * and the number of entries should be equal to n_env. 
+ * @param[in] final_state_shape A pointer to an array specifying the shape of the final_state data. Length has to be
+ * equal to 1 and the number of entries should be equal to n_env.
  * @param[out] dtype The TorchFort datatype to use for this operation.
  * @param[out] stream CUDA stream to enqueue the action prediction operations.
  *
  * @return \p TORCHFORT_RESULT_SUCCESS on success or error code on failure.
  */
-torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi(const char* name,
-								      void* state, size_t state_dim, int64_t* state_shape,
-								      void* action, size_t action_dim, int64_t* action_shape,
-								      void* reward, size_t reward_dim, int64_t* reward_shape,
-								      void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-								      torchfort_datatype_t dtype, cudaStream_t stream);
+torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi(
+    const char* name, void* state, size_t state_dim, int64_t* state_shape, void* action, size_t action_dim,
+    int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t stream);
 
-torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi_F(const char* name,
-								        void* state, size_t state_dim, int64_t* state_shape,
-								        void* action, size_t action_dim, int64_t* action_shape,
-								        void* reward, size_t reward_dim, int64_t* reward_shape,
-								        void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-								        torchfort_datatype_t dtype, cudaStream_t stream);
+torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi_F(
+    const char* name, void* state, size_t state_dim, int64_t* state_shape, void* action, size_t action_dim,
+    int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t stream);
 
 /**
  * @brief Resets the rollout buffer

--- a/src/csrc/losses/l1_loss.cpp
+++ b/src/csrc/losses/l1_loss.cpp
@@ -58,8 +58,7 @@ void L1Loss::setup(const ParamMap& params) {
   module = torch::nn::L1Loss(options);
 }
 
-torch::Tensor L1Loss::forward(const std::vector<torch::Tensor>& inputs,
-                              const std::vector<torch::Tensor>& labels,
+torch::Tensor L1Loss::forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                               const std::vector<torch::Tensor>& extra_args) {
   if (inputs.size() != 1 || labels.size() != 1 || extra_args.size() != 0) {
     THROW_INVALID_USAGE("L1Loss only supports one input tensor, one label tensor, and no extra arguments.");

--- a/src/csrc/losses/mse_loss.cpp
+++ b/src/csrc/losses/mse_loss.cpp
@@ -59,8 +59,7 @@ void MSELoss::setup(const ParamMap& params) {
   module = torch::nn::MSELoss(options);
 }
 
-torch::Tensor MSELoss::forward(const std::vector<torch::Tensor>& inputs,
-                               const std::vector<torch::Tensor>& labels,
+torch::Tensor MSELoss::forward(const std::vector<torch::Tensor>& inputs, const std::vector<torch::Tensor>& labels,
                                const std::vector<torch::Tensor>& extra_args) {
   if (inputs.size() != 1 || labels.size() != 1 || extra_args.size() != 0) {
     THROW_INVALID_USAGE("MSELoss only supports one input tensor, one label tensor, and no extra arguments.");

--- a/src/csrc/rl/off_policy/ddpg.cpp
+++ b/src/csrc/rl/off_policy/ddpg.cpp
@@ -361,7 +361,8 @@ void DDPGSystem::loadCheckpoint(const std::string& checkpoint_dir) {
 }
 
 // we should pass a tuple (s, a, s', r, d)
-void DDPGSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d) {
+void DDPGSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r,
+                                    torch::Tensor d) {
   replay_buffer_->update(s, a, sp, r, d);
 }
 

--- a/src/csrc/rl/off_policy/interface.cpp
+++ b/src/csrc/rl/off_policy/interface.cpp
@@ -274,33 +274,26 @@ torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_F(const char* na
   return TORCHFORT_RESULT_SUCCESS;
 }
 
-torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi(const char* name, void* state_old,
-								      void* state_new, size_t state_dim, int64_t* state_shape,
-                                                                      void* action_old, size_t action_dim, int64_t* action_shape,
-								      void* reward, size_t reward_dim, int64_t* reward_shape,
-                                                                      void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-								      torchfort_datatype_t dtype, cudaStream_t ext_stream) {
+torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi(
+    const char* name, void* state_old, void* state_new, size_t state_dim, int64_t* state_shape, void* action_old,
+    size_t action_dim, int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t ext_stream) {
   using namespace torchfort;
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT: {
       rl::off_policy::update_replay_buffer<RowMajor>(
-          name, reinterpret_cast<float*>(state_old),
-	  reinterpret_cast<float*>(state_new), state_dim, state_shape,
-          reinterpret_cast<float*>(action_old), action_dim, action_shape,
-	  reinterpret_cast<float*>(reward), reward_dim, reward_shape,
-	  reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape,
-	  ext_stream);
+          name, reinterpret_cast<float*>(state_old), reinterpret_cast<float*>(state_new), state_dim, state_shape,
+          reinterpret_cast<float*>(action_old), action_dim, action_shape, reinterpret_cast<float*>(reward), reward_dim,
+          reward_shape, reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape, ext_stream);
       break;
     }
     case TORCHFORT_DOUBLE: {
       rl::off_policy::update_replay_buffer<RowMajor>(
-          name, reinterpret_cast<double*>(state_old),
-	  reinterpret_cast<double*>(state_new), state_dim, state_shape,
-          reinterpret_cast<double*>(action_old), action_dim, action_shape,
-	  reinterpret_cast<double*>(reward), reward_dim, reward_shape,
-          reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape,
-	  ext_stream);
+          name, reinterpret_cast<double*>(state_old), reinterpret_cast<double*>(state_new), state_dim, state_shape,
+          reinterpret_cast<double*>(action_old), action_dim, action_shape, reinterpret_cast<double*>(reward),
+          reward_dim, reward_shape, reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape,
+          ext_stream);
       break;
     }
     default: {
@@ -315,34 +308,26 @@ torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi(const char
   return TORCHFORT_RESULT_SUCCESS;
 }
 
-torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi_F(const char* name, void* state_old,
-									void* state_new, size_t state_dim, int64_t* state_shape,
-									void* action_old, size_t action_dim, int64_t* action_shape,
-									void* reward, size_t reward_dim, int64_t* reward_shape,
-									void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-									torchfort_datatype_t dtype, cudaStream_t stream) {
+torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi_F(
+    const char* name, void* state_old, void* state_new, size_t state_dim, int64_t* state_shape, void* action_old,
+    size_t action_dim, int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t stream) {
   using namespace torchfort;
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT: {
-     
+
       rl::off_policy::update_replay_buffer<ColMajor>(
-						     name, reinterpret_cast<float*>(state_old),
-						     reinterpret_cast<float*>(state_new), state_dim, state_shape,
-						     reinterpret_cast<float*>(action_old), action_dim, action_shape,
-						     reinterpret_cast<float*>(reward), reward_dim, reward_shape,
-						     reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape,
-						     stream);
+          name, reinterpret_cast<float*>(state_old), reinterpret_cast<float*>(state_new), state_dim, state_shape,
+          reinterpret_cast<float*>(action_old), action_dim, action_shape, reinterpret_cast<float*>(reward), reward_dim,
+          reward_shape, reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape, stream);
       break;
     }
     case TORCHFORT_DOUBLE: {
       rl::off_policy::update_replay_buffer<ColMajor>(
-						     name, reinterpret_cast<double*>(state_old),
-						     reinterpret_cast<double*>(state_new), state_dim, state_shape,
-						     reinterpret_cast<double*>(action_old), action_dim, action_shape,
-						     reinterpret_cast<double*>(reward), reward_dim, reward_shape,
-                                                     reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape,
-						     stream);
+          name, reinterpret_cast<double*>(state_old), reinterpret_cast<double*>(state_new), state_dim, state_shape,
+          reinterpret_cast<double*>(action_old), action_dim, action_shape, reinterpret_cast<double*>(reward),
+          reward_dim, reward_shape, reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape, stream);
       break;
     }
     default: {
@@ -356,7 +341,6 @@ torchfort_result_t torchfort_rl_off_policy_update_replay_buffer_multi_F(const ch
   }
   return TORCHFORT_RESULT_SUCCESS;
 }
-
 
 torchfort_result_t torchfort_rl_off_policy_predict_explore(const char* name, void* state, size_t state_dim,
                                                            int64_t* state_shape, void* action, size_t action_dim,
@@ -476,7 +460,7 @@ torchfort_result_t torchfort_rl_off_policy_evaluate(const char* name, void* stat
   if (reward_dim != 1) {
     THROW_INVALID_USAGE("The dimension of the reward array has to be equal to 1.");
   }
-  
+
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT:

--- a/src/csrc/rl/off_policy/sac.cpp
+++ b/src/csrc/rl/off_policy/sac.cpp
@@ -265,7 +265,7 @@ torch::Device SACSystem::modelDevice() const { return model_device_; }
 
 torch::Device SACSystem::rbDevice() const { return rb_device_; }
 
-int SACSystem::getRank() const	{
+int SACSystem::getRank() const {
   if (!system_comm_) {
     return 0;
   } else {
@@ -503,10 +503,11 @@ void SACSystem::loadCheckpoint(const std::string& checkpoint_dir) {
   }
 }
 
-// we should pass a tuple (s, a, s', r, d)  
-void SACSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d) {
+// we should pass a tuple (s, a, s', r, d)
+void SACSystem::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r,
+                                   torch::Tensor d) {
   // note that we have to rescale the action: [a_low, a_high] -> [-1, 1],
-  // but the replay buffer only stores scaled actions! 
+  // but the replay buffer only stores scaled actions!
   replay_buffer_->update(s, a, sp, r, d);
 }
 

--- a/src/csrc/rl/off_policy/td3.cpp
+++ b/src/csrc/rl/off_policy/td3.cpp
@@ -253,7 +253,7 @@ torch::Device TD3System::modelDevice() const { return model_device_; }
 
 torch::Device TD3System::rbDevice() const { return rb_device_; }
 
-int TD3System::getRank() const	{
+int TD3System::getRank() const {
   if (!system_comm_) {
     return 0;
   } else {
@@ -407,7 +407,8 @@ void TD3System::loadCheckpoint(const std::string& checkpoint_dir) {
 }
 
 // we should pass a tuple (s, a, s', r, d)
-  void TD3System::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r, torch::Tensor d) {
+void TD3System::updateReplayBuffer(torch::Tensor s, torch::Tensor a, torch::Tensor sp, torch::Tensor r,
+                                   torch::Tensor d) {
   replay_buffer_->update(s, a, sp, r, d);
 }
 

--- a/src/csrc/rl/on_policy/interface.cpp
+++ b/src/csrc/rl/on_policy/interface.cpp
@@ -260,31 +260,25 @@ torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_F(const char* na
 }
 
 // multi env
-torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi(const char* name,
-								      void* state, size_t state_dim, int64_t* state_shape,
-								      void* action, size_t action_dim, int64_t* action_shape,
-								      void* reward, size_t reward_dim, int64_t* reward_shape,
-                                                                      void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-								      torchfort_datatype_t dtype, cudaStream_t ext_stream) {
+torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi(
+    const char* name, void* state, size_t state_dim, int64_t* state_shape, void* action, size_t action_dim,
+    int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t ext_stream) {
   using namespace torchfort;
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT: {
-      rl::on_policy::update_rollout_buffer<RowMajor>(name,
-						     reinterpret_cast<float*>(state), state_dim, state_shape,
-                                                     reinterpret_cast<float*>(action), action_dim, action_shape,
-						     reinterpret_cast<float*>(reward), reward_dim, reward_shape,
-						     reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape,
-                                                     ext_stream);
+      rl::on_policy::update_rollout_buffer<RowMajor>(
+          name, reinterpret_cast<float*>(state), state_dim, state_shape, reinterpret_cast<float*>(action), action_dim,
+          action_shape, reinterpret_cast<float*>(reward), reward_dim, reward_shape,
+          reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape, ext_stream);
       break;
     }
     case TORCHFORT_DOUBLE: {
-      rl::on_policy::update_rollout_buffer<RowMajor>(name,
-						     reinterpret_cast<double*>(state), state_dim, state_shape,
-                                                     reinterpret_cast<double*>(action), action_dim, action_shape,
-						     reinterpret_cast<double*>(reward), reward_dim, reward_shape,
-                                                     reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape,
-                                                     ext_stream);
+      rl::on_policy::update_rollout_buffer<RowMajor>(
+          name, reinterpret_cast<double*>(state), state_dim, state_shape, reinterpret_cast<double*>(action), action_dim,
+          action_shape, reinterpret_cast<double*>(reward), reward_dim, reward_shape,
+          reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape, ext_stream);
       break;
     }
     default: {
@@ -299,32 +293,26 @@ torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi(const char
   return TORCHFORT_RESULT_SUCCESS;
 }
 
-torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi_F(const char* name,
-									void* state, size_t state_dim, int64_t* state_shape,
-									void* action, size_t action_dim, int64_t* action_shape,
-									void* reward, size_t reward_dim, int64_t* reward_shape,
-									void* final_state, size_t final_state_dim, int64_t* final_state_shape,
-									torchfort_datatype_t dtype, cudaStream_t ext_stream) {
+torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi_F(
+    const char* name, void* state, size_t state_dim, int64_t* state_shape, void* action, size_t action_dim,
+    int64_t* action_shape, void* reward, size_t reward_dim, int64_t* reward_shape, void* final_state,
+    size_t final_state_dim, int64_t* final_state_shape, torchfort_datatype_t dtype, cudaStream_t ext_stream) {
 
   using namespace torchfort;
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT: {
-      rl::on_policy::update_rollout_buffer<ColMajor>(name,
-						     reinterpret_cast<float*>(state), state_dim, state_shape,
-                                                     reinterpret_cast<float*>(action), action_dim, action_shape,
-						     reinterpret_cast<float*>(reward), reward_dim, reward_shape,
-                                                     reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape,
-                                                     ext_stream);
+      rl::on_policy::update_rollout_buffer<ColMajor>(
+          name, reinterpret_cast<float*>(state), state_dim, state_shape, reinterpret_cast<float*>(action), action_dim,
+          action_shape, reinterpret_cast<float*>(reward), reward_dim, reward_shape,
+          reinterpret_cast<float*>(final_state), final_state_dim, final_state_shape, ext_stream);
       break;
     }
     case TORCHFORT_DOUBLE: {
-      rl::on_policy::update_rollout_buffer<ColMajor>(name,
-						     reinterpret_cast<double*>(state), state_dim, state_shape,
-                                                     reinterpret_cast<double*>(action), action_dim, action_shape,
-						     reinterpret_cast<double*>(reward), reward_dim, reward_shape,
-                                                     reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape,
-                                                     ext_stream);
+      rl::on_policy::update_rollout_buffer<ColMajor>(
+          name, reinterpret_cast<double*>(state), state_dim, state_shape, reinterpret_cast<double*>(action), action_dim,
+          action_shape, reinterpret_cast<double*>(reward), reward_dim, reward_shape,
+          reinterpret_cast<double*>(final_state), final_state_dim, final_state_shape, ext_stream);
       break;
     }
     default: {
@@ -338,7 +326,6 @@ torchfort_result_t torchfort_rl_on_policy_update_rollout_buffer_multi_F(const ch
   }
   return TORCHFORT_RESULT_SUCCESS;
 }
-
 
 torchfort_result_t torchfort_rl_on_policy_reset_rollout_buffer(const char* name) {
   using namespace torchfort;
@@ -464,11 +451,11 @@ torchfort_result_t torchfort_rl_on_policy_evaluate(const char* name, void* state
                                                    int64_t* reward_shape, torchfort_datatype_t dtype,
                                                    cudaStream_t ext_stream) {
   using namespace torchfort;
-  
+
   if (reward_dim != 1) {
     THROW_INVALID_USAGE("The dimension of the reward array has to be equal to 1.");
   }
-  
+
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT:
@@ -502,7 +489,7 @@ torchfort_result_t torchfort_rl_on_policy_evaluate_F(const char* name, void* sta
   if (reward_dim != 1) {
     THROW_INVALID_USAGE("The dimension of the reward array has to be equal to 1.");
   }
-  
+
   try {
     switch (dtype) {
     case TORCHFORT_FLOAT:

--- a/src/csrc/rl/on_policy/ppo.cpp
+++ b/src/csrc/rl/on_policy/ppo.cpp
@@ -308,15 +308,16 @@ void PPOSystem::loadCheckpoint(const std::string& checkpoint_dir) {
 void PPOSystem::updateRolloutBuffer(torch::Tensor stens, torch::Tensor atens, float r, bool d) {
   auto options = torch::TensorOptions().dtype(torch::kFloat32).device(rb_device_);
   torch::Tensor stensu = torch::unsqueeze(stens, 0);
-  torch::Tensor	atensu = torch::unsqueeze(atens, 0);
+  torch::Tensor atensu = torch::unsqueeze(atens, 0);
   torch::Tensor rtens = torch::tensor({r}, options);
   torch::Tensor etens = torch::tensor({d ? 1. : 0.}, options);
 
   updateRolloutBuffer(stensu, atensu, rtens, etens);
 }
-  
+
 // we should pass a tuple (s, a, r, d)
-void PPOSystem::updateRolloutBuffer(torch::Tensor stens, torch::Tensor atens, torch::Tensor rtens, torch::Tensor etens) {
+void PPOSystem::updateRolloutBuffer(torch::Tensor stens, torch::Tensor atens, torch::Tensor rtens,
+                                    torch::Tensor etens) {
   // note that we have to rescale the action: [a_low, a_high] -> [-1, 1]
   torch::Tensor as;
   switch (actor_normalization_mode_) {

--- a/src/csrc/rl/policy.cpp
+++ b/src/csrc/rl/policy.cpp
@@ -110,8 +110,8 @@ std::tuple<torch::Tensor, torch::Tensor> GaussianPolicy::forwardNoise(torch::Ten
 
   // account for squashing
   if (squashed_) {
-    log_prob =
-        log_prob - torch::sum(torch::flatten(2. * (std::log(2.) - action - torch::softplus(-2. * action)), 1), 1, false);
+    log_prob = log_prob -
+               torch::sum(torch::flatten(2. * (std::log(2.) - action - torch::softplus(-2. * action)), 1), 1, false);
     action = torch::tanh(action);
   }
 
@@ -197,7 +197,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GaussianACPolicy::evalua
 
   // squeeze value
   value = torch::squeeze(value, 1);
-  
+
   return std::make_tuple(log_prob, entropy, value);
 }
 
@@ -214,8 +214,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GaussianACPolicy::forwar
 
   // account for squashing
   if (squashed_) {
-    log_prob =
-        log_prob - torch::sum(torch::flatten(2. * (std::log(2.) - action - torch::softplus(-2. * action)), 1), 1, false);
+    log_prob = log_prob -
+               torch::sum(torch::flatten(2. * (std::log(2.) - action - torch::softplus(-2. * action)), 1), 1, false);
     action = torch::tanh(action);
   }
 

--- a/src/csrc/torchfort.cpp
+++ b/src/csrc/torchfort.cpp
@@ -222,8 +222,9 @@ torchfort_result_t torchfort_train_F(const char* name, void* input, size_t input
   return TORCHFORT_RESULT_SUCCESS;
 }
 
-torchfort_result_t torchfort_train_multiarg(const char* name, torchfort_tensor_list_t inputs, torchfort_tensor_list_t labels,
-                                            float* loss_val, torchfort_tensor_list_t extra_loss_args, cudaStream_t stream) {
+torchfort_result_t torchfort_train_multiarg(const char* name, torchfort_tensor_list_t inputs,
+                                            torchfort_tensor_list_t labels, float* loss_val,
+                                            torchfort_tensor_list_t extra_loss_args, cudaStream_t stream) {
   using namespace torchfort;
   try {
     torchfort::train_multiarg(name, inputs, labels, loss_val, extra_loss_args, stream);
@@ -415,8 +416,8 @@ torchfort_result_t torchfort_tensor_list_add_tensor(torchfort_tensor_list_t tens
   return TORCHFORT_RESULT_SUCCESS;
 }
 
-torchfort_result_t torchfort_tensor_list_add_tensor_F(torchfort_tensor_list_t tensor_list_in, void* data_ptr, size_t dim,
-                                                      int64_t* shape, torchfort_datatype_t dtype) {
+torchfort_result_t torchfort_tensor_list_add_tensor_F(torchfort_tensor_list_t tensor_list_in, void* data_ptr,
+                                                      size_t dim, int64_t* shape, torchfort_datatype_t dtype) {
   using namespace torchfort;
   try {
     auto tensor_list = static_cast<torchfort::TensorList*>(tensor_list_in);

--- a/src/csrc/training.cpp
+++ b/src/csrc/training.cpp
@@ -126,7 +126,8 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
 
   inputs->to(model->device());
   labels->to(model->device());
-  if (extra_loss_args) extra_loss_args->to(model->device());
+  if (extra_loss_args)
+    extra_loss_args->to(model->device());
 
   model->train();
   auto opt = models[name].optimizer;
@@ -134,8 +135,8 @@ void train_multiarg(const char* name, torchfort_tensor_list_t inputs_in, torchfo
 
   // fwd pass
   auto results = model->forward(inputs->tensors);
-  auto loss =
-      models[name].loss->forward(results, labels->tensors, (extra_loss_args) ? extra_loss_args->tensors : std::vector<torch::Tensor>());
+  auto loss = models[name].loss->forward(results, labels->tensors,
+                                         (extra_loss_args) ? extra_loss_args->tensors : std::vector<torch::Tensor>());
 
   // extract loss
   *loss_val = loss.item<float>();

--- a/src/csrc/utils.cpp
+++ b/src/csrc/utils.cpp
@@ -115,5 +115,4 @@ std::vector<double> get_current_lrs(const char* name) {
   return learnings_rates;
 }
 
-
 } // namespace torchfort


### PR DESCRIPTION
This PR adds basic build and format check workflows to the CI. In particular, it adds `clang-format` checks to all PR commits. Additionally, it adds the option to trigger a build and functionality test via a PR comment (\build_and_test). Since we are using GitHub CPU runners, only the CPU build is tested; however, the GPU compilation using NVHPC and GNU host compilers is checked. 

To get the formatting tests to pass, `clang-format` was applied to the codebase as part of this PR.