### PR TITLE
Revert "Explicitly disallow multiple input tensors from built-in MLP and SACMLP models. (#73)"

### DIFF
--- a/src/csrc/models/mlp_model.cpp
+++ b/src/csrc/models/mlp_model.cpp
@@ -59,10 +59,8 @@ void MLPModel::setup(const ParamMap& params) {
 
 // Implement the forward function.
 std::vector<torch::Tensor> MLPModel::forward(const std::vector<torch::Tensor>& inputs) {
-  if (inputs.size() > 1)
-    THROW_INVALID_USAGE("Built-in MLP model does not support multiple input tensors.");
-
-  auto x = inputs[0];
+  // concatenate inputs
+  auto x = torch::cat(inputs, 1);
   x = x.reshape({x.size(0), -1});
 
   for (int i = 0; i < layer_sizes.size() - 1; ++i) {

--- a/src/csrc/models/sac_model.cpp
+++ b/src/csrc/models/sac_model.cpp
@@ -45,12 +45,9 @@ void SACMLPModel::setup(const ParamMap& params) {
 
 // Implement the forward function.
 std::vector<torch::Tensor> SACMLPModel::forward(const std::vector<torch::Tensor>& inputs) {
-  if (inputs.size() > 1)
-    THROW_INVALID_USAGE("Built-in SACMLP model does not support multiple input tensors.");
-
-  auto x = inputs[0];
+  // concatenate inputs
+  auto x = torch::cat(inputs, 1);
   x = x.reshape({x.size(0), -1});
-
   torch::Tensor y, z;
 
   for (int i = 0; i < layer_sizes.size() - 1; ++i) {


### PR DESCRIPTION
#73 introduced issues with current RL tests which use the built-in MLP for the critic network which passes in multiple input tensors (state and action). 

Reverting this change for now.