### PR TITLE
Add build configured torchfort_config.h header to indicate GPU support in build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,13 @@ endif()
 
 find_package(Torch REQUIRED)
 
+# Generate configuration header
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/csrc/include/torchfort_config.h.in
+  ${CMAKE_BINARY_DIR}/include/torchfort_config.h
+  @ONLY
+)
+
 # yaml-cpp
 #find_package(yaml-cpp REQUIRED)
 find_path(YAML_CPP_INCLUDE_DIR REQUIRED
@@ -170,6 +177,7 @@ target_include_directories(${PROJECT_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/src/csrc/include
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/csrc/include>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
@@ -207,6 +215,12 @@ install(
   EXPORT "${PROJECT_NAME}Targets"
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include
   INCLUDES DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
+
+# Install generated configuration header
+install(
+  FILES ${CMAKE_BINARY_DIR}/include/torchfort_config.h
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/include
 )
 
 # Fortran library and module

--- a/src/csrc/include/torchfort.h
+++ b/src/csrc/include/torchfort.h
@@ -16,8 +16,8 @@
  */
 
 #pragma once
-#include <stdint.h>
 #include "torchfort_config.h"
+#include <stdint.h>
 #if TORCHFORT_ENABLE_GPU
 #include <cuda_runtime.h>
 #else

--- a/src/csrc/include/torchfort.h
+++ b/src/csrc/include/torchfort.h
@@ -17,7 +17,8 @@
 
 #pragma once
 #include <stdint.h>
-#ifdef ENABLE_GPU
+#include "torchfort_config.h"
+#if TORCHFORT_ENABLE_GPU
 #include <cuda_runtime.h>
 #else
 typedef void* cudaStream_t;

--- a/src/csrc/include/torchfort_config.h.in
+++ b/src/csrc/include/torchfort_config.h.in
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/* Define to 1 if TorchFort was built with GPU support */
+#cmakedefine01 TORCHFORT_ENABLE_GPU
+

--- a/src/csrc/include/torchfort_rl.h
+++ b/src/csrc/include/torchfort_rl.h
@@ -16,8 +16,9 @@
  */
 
 #pragma once
+#include "torchfort_config.h"
 #include "torchfort_enums.h"
-#ifdef ENABLE_GPU
+#if TORCHFORT_ENABLE_GPU
 #include <cuda_runtime.h>
 #else
 typedef void* cudaStream_t;


### PR DESCRIPTION
Our current `torchfort.h` and `torchfort_rl.h` header files use `#ifdef ENABLE_GPU` preprocessor macros to control whether `cudaStream_t` is redefined to enable CPU only builds. The issue is that this macro is only defined when building the library, so users building external applications with CUDA can run into problems when including these headers. In particular, if they don't also define `ENABLE_GPU` in their compilation, they will run into redefinition errors.

For example, compiling the following program:
```
#include <torchfort.h>
#include <cuda_runtime.h>

int main(int argc, char* argv[]) {
}
```
using a typical compilation line like:
```
mpicxx -I${TORCHFORT_ROOT}/include -I${CUDA_ROOT}/include example.cpp
``` 
results in the following error:
```
"/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda/include/driver_types.h", line 3035: error: invalid redeclaration of type name "cudaStream_t" (declared at line 23 of "/opt/torchfort/include/torchfort.h")
  typedef __device_builtin__ struct CUstream_st *cudaStream_t;
```
which can be resolved by adding `-DENABLE_GPU` to the compile line, which is not great user experience.

To fix this, this PR introduces a build time created `torch_config.h` which will define `TORCHFORT_ENABLE_GPU` to indicate whether TorchFort was built with GPU support or not. This configuration header is then included in `torchfort.h` and `torchfort_rl.h` to control whether `cudaStream_t` is redefined or not, removing the need for users to define `ENABLE_GPU` themselves anymore.

