### PR TITLE
RL: first round of some fixes and improvements

### DIFF
--- a/src/csrc/include/internal/rl/off_policy/ddpg.h
+++ b/src/csrc/include/internal/rl/off_policy/ddpg.h
@@ -122,7 +122,14 @@ void train_ddpg(const ModelPack& p_model, const ModelPack& p_model_target, const
   }
 
   // save loss values
-  q_loss_val = q_loss_tensor.item<T>();
+  torch::Tensor q_loss_mean_tensor = q_loss_tensor;
+  if (q_model.comm) {
+    torch::NoGradGuard no_grad;
+    std::vector<torch::Tensor> q_loss_mean = {q_loss_tensor};
+    q_model.comm->allreduce(q_loss_mean, true);
+    q_loss_mean_tensor = q_loss_mean[0];
+  }
+  q_loss_val = q_loss_mean_tensor.item<T>();
 
   // policy function
   // freeze the q1model
@@ -170,11 +177,21 @@ void train_ddpg(const ModelPack& p_model, const ModelPack& p_model_target, const
   set_grad_state(q_model.model, true);
 
   // save loss val
-  p_loss_val = p_loss_tensor.item<T>();
+  torch::Tensor p_loss_mean_tensor = p_loss_tensor;
+  if (p_model.comm) {
+    torch::NoGradGuard no_grad;
+    std::vector<torch::Tensor> p_loss_mean = {p_loss_tensor};
+    p_model.comm->allreduce(p_loss_mean, true);
+    p_loss_mean_tensor = p_loss_mean[0];
+  }
+  p_loss_val = p_loss_mean_tensor.item<T>();
 
-  // do polyak averaging:
-  polyak_update<T>(q_model_target.model, q_model.model, rho);
-  polyak_update<T>(p_model_target.model, p_model.model, rho);
+  // do polyak averaging: only perform if the optimizer stepped (i.e. gradient accumulation is complete)
+  state = p_model.state;
+  if ((state->step_train_current + 1) % p_model.grad_accumulation_steps == 0) {
+    polyak_update<T>(q_model_target.model, q_model.model, rho);
+    polyak_update<T>(p_model_target.model, p_model.model, rho);
+  }
 
   // print some info
   // value functions

--- a/src/csrc/include/internal/rl/off_policy/sac.h
+++ b/src/csrc/include/internal/rl/off_policy/sac.h
@@ -288,11 +288,21 @@ void train_sac(const PolicyPack& p_model, const std::vector<ModelPack>& q_models
   }
 
   // save loss val
-  p_loss_val = p_loss_tensor.item<T>();
+  torch::Tensor p_loss_mean_tensor = p_loss_tensor;
+  if (p_model.comm) {
+    torch::NoGradGuard no_grad;
+    std::vector<torch::Tensor> p_loss_mean = {p_loss_tensor};
+    p_model.comm->allreduce(p_loss_mean, true);
+    p_loss_mean_tensor = p_loss_mean[0];
+  }
+  p_loss_val = p_loss_mean_tensor.item<T>();
 
-  // do polyak averaging: only if we also trained the policy
-  for (int i = 0; i < q_models_target.size(); ++i) {
-    polyak_update<T>(q_models_target[i].model, q_models[i].model, rho);
+  // do polyak averaging: only perform if the optimizer stepped (i.e. gradient accumulation is complete)
+  state = p_model.state;
+  if ((state->step_train_current + 1) % p_model.grad_accumulation_steps == 0) {
+    for (int i = 0; i < q_models_target.size(); ++i) {
+      polyak_update<T>(q_models_target[i].model, q_models[i].model, rho);
+    }
   }
 
   // print some info

--- a/src/csrc/rl/off_policy/ddpg.cpp
+++ b/src/csrc/rl/off_policy/ddpg.cpp
@@ -55,7 +55,7 @@ DDPGSystem::DDPGSystem(const char* name, const YAML::Node& system_node, int mode
     } else if (redmode == "weighted_mean_no_skip") {
       nstep_reward_reduction_ = RewardReductionMode::WeightedMeanNoSkip;
     } else {
-      std::invalid_argument("Unknown nstep_reward_reduction specified");
+      THROW_INVALID_USAGE("Unknown nstep_reward_reduction specified: " + redmode);
     }
   } else {
     THROW_INVALID_USAGE("Missing parameters section in algorithm section in configuration file.");
@@ -425,12 +425,12 @@ torch::Tensor DDPGSystem::predict(torch::Tensor state) {
   torch::NoGradGuard no_grad;
 
   // prepare inputs
-  p_model_target_.model->to(model_device_);
-  p_model_target_.model->eval();
+  p_model_.model->to(model_device_);
+  p_model_.model->eval();
   state = state.to(model_device_);
 
   // do fwd pass
-  auto action = (p_model_target_.model)->forward(std::vector<torch::Tensor>{state})[0];
+  auto action = (p_model_.model)->forward(std::vector<torch::Tensor>{state})[0];
 
   // clip action
   action = torch::clamp(action, a_low_, a_high_);
@@ -461,13 +461,13 @@ torch::Tensor DDPGSystem::evaluate(torch::Tensor state, torch::Tensor action) {
   torch::NoGradGuard no_grad;
 
   // prepare inputs
-  q_model_target_.model->to(model_device_);
-  q_model_target_.model->eval();
+  q_model_.model->to(model_device_);
+  q_model_.model->eval();
   state = state.to(model_device_);
   action = action.to(model_device_);
 
   // do fwd pass
-  torch::Tensor reward = (q_model_target_.model)->forward(std::vector<torch::Tensor>{state, action})[0];
+  torch::Tensor reward = (q_model_.model)->forward(std::vector<torch::Tensor>{state, action})[0];
 
   // squeeze
   reward = torch::squeeze(reward, 1);

--- a/src/csrc/rl/off_policy/sac.cpp
+++ b/src/csrc/rl/off_policy/sac.cpp
@@ -75,7 +75,7 @@ SACSystem::SACSystem(const char* name, const YAML::Node& system_node, int model_
     alpha_model_ = std::make_shared<AlphaModel>(am);
     alpha_model_->to(model_device_);
     // remaining parameters
-    target_entropy_ = params.get_param<float>("target_entropy_", 1.)[0];
+    target_entropy_ = params.get_param<float>("target_entropy", 1.)[0];
     nstep_ = params.get_param<int>("nstep", 1)[0];
     auto redmode = params.get_param<std::string>("nstep_reward_reduction", "sum")[0];
     if (redmode == "sum") {
@@ -85,7 +85,7 @@ SACSystem::SACSystem(const char* name, const YAML::Node& system_node, int model_
     } else if (redmode == "weighted_mean") {
       nstep_reward_reduction_ = RewardReductionMode::WeightedMean;
     } else {
-      std::invalid_argument("Unknown nstep_reward_reduction specified");
+      THROW_INVALID_USAGE("Unknown nstep_reward_reduction specified: " + redmode);
     }
   } else {
     THROW_INVALID_USAGE("Missing parameters section in algorithm section in configuration file.");
@@ -214,6 +214,16 @@ SACSystem::SACSystem(const char* name, const YAML::Node& system_node, int model_
   if (system_node["alpha_optimizer"]) {
     // register alpha as a new parameter
     alpha_optimizer_ = get_optimizer(system_node["alpha_optimizer"], alpha_model_->parameters());
+    // if alpha was initialized to 0, alpha_coeff_ is false and AlphaModel::forward returns 0
+    // unconditionally, meaning the optimizer has no effect on training — enable it and warn
+    if (!alpha_model_->alpha_coeff_) {
+      alpha_model_->alpha_coeff_ = true;
+      torchfort::logging::print(
+          "SAC: alpha_optimizer is configured but alpha was set to 0. Enabling entropy regularization "
+          "with the initial value alpha = 0.01 (log_alpha = log(0.01)). Set a nonzero alpha in the "
+          "config to suppress this warning and control the initial value.",
+          torchfort::logging::warn);
+    }
   } else {
     alpha_optimizer_ = nullptr;
   }
@@ -606,13 +616,13 @@ torch::Tensor SACSystem::evaluate(torch::Tensor state, torch::Tensor action) {
   torch::NoGradGuard no_grad;
 
   // prepare inputs
-  q_models_target_[0].model->to(model_device_);
-  q_models_target_[0].model->eval();
+  q_models_[0].model->to(model_device_);
+  q_models_[0].model->eval();
   state = state.to(model_device_);
   action = action.to(model_device_);
 
   // do fwd pass
-  torch::Tensor reward = (q_models_target_[0].model)->forward(std::vector<torch::Tensor>{state, action})[0];
+  torch::Tensor reward = (q_models_[0].model)->forward(std::vector<torch::Tensor>{state, action})[0];
 
   // squeeze
   reward = torch::squeeze(reward, 1);

--- a/src/csrc/rl/off_policy/td3.cpp
+++ b/src/csrc/rl/off_policy/td3.cpp
@@ -57,7 +57,7 @@ TD3System::TD3System(const char* name, const YAML::Node& system_node, int model_
     } else if (redmode == "weighted_mean_no_skip") {
       nstep_reward_reduction_ = RewardReductionMode::WeightedMeanNoSkip;
     } else {
-      std::invalid_argument("Unknown nstep_reward_reduction specified");
+      THROW_INVALID_USAGE("Unknown nstep_reward_reduction specified: " + redmode);
     }
   } else {
     THROW_INVALID_USAGE("Missing parameters section in algorithm section in configuration file.");
@@ -79,7 +79,19 @@ TD3System::TD3System(const char* name, const YAML::Node& system_node, int model_
       float mu = 0.f;
       bool adaptive = params.get_param<bool>("adaptive", false)[0];
 
-      // we need to set up the noise actor type:
+      // Two separate noise actors are constructed from these parameters:
+      //
+      // noise_actor_train_ (sigma_train, clip): used exclusively for TARGET POLICY SMOOTHING,
+      //   i.e. adding clipped noise to the target actor's actions when computing Bellman targets:
+      //   y = r + gamma * min(Q1_targ, Q2_targ)(s', clip(mu_targ(s') + eps, a_low, a_high))
+      //   where eps ~ clip(N(0, sigma_train), -clip, clip).
+      //   This regularizes the Q-value estimate against narrow peaks. The TD3 paper recommends
+      //   sigma_train=0.2 and clip=0.5 (as fractions of the action range).
+      //   NOTE: despite the name "train", this has nothing to do with the policy gradient update.
+      //
+      // noise_actor_exploration_ (sigma_explore): used during environment rollout collection,
+      //   i.e. the noise added to the live policy when gathering experience. The TD3 paper
+      //   recommends sigma_explore=0.1.
       if (noise_actor_type == "space_noise") {
         noise_actor_train_ = std::make_shared<ActionNoise<float>>(mu, sigma_train, clip, adaptive);
         noise_actor_exploration_ = std::make_shared<ActionNoise<float>>(mu, sigma_explore, 0.f, adaptive);
@@ -88,6 +100,11 @@ TD3System::TD3System(const char* name, const YAML::Node& system_node, int model_
         float xi = params.get_param<float>("xi", 0.)[0];
         noise_actor_train_ = std::make_shared<ActionNoiseOU<float>>(mu, sigma_train, clip, dt, xi, adaptive);
         noise_actor_exploration_ = std::make_shared<ActionNoiseOU<float>>(mu, sigma_explore, 0.f, dt, xi, adaptive);
+        torchfort::logging::print(
+            "TD3: OU noise is used for target policy smoothing. OU noise is temporally correlated and violates "
+            "the i.i.d. assumption required by TD3 target policy smoothing. This can bias Q-value targets across "
+            "training steps. Consider using space_noise (i.i.d. Gaussian) for the training noise instead.",
+            torchfort::logging::warn);
       } else if (noise_actor_type == "parameter_noise") {
         noise_actor_train_ = std::make_shared<ParameterNoise<float>>(mu, sigma_train, clip, adaptive);
         noise_actor_exploration_ = std::make_shared<ParameterNoise<float>>(mu, sigma_explore, 0.f, adaptive);
@@ -96,6 +113,11 @@ TD3System::TD3System(const char* name, const YAML::Node& system_node, int model_
         float xi = params.get_param<float>("xi", 0.)[0];
         noise_actor_train_ = std::make_shared<ParameterNoiseOU<float>>(mu, sigma_train, clip, dt, xi, adaptive);
         noise_actor_exploration_ = std::make_shared<ParameterNoiseOU<float>>(mu, sigma_explore, 0.f, dt, xi, adaptive);
+        torchfort::logging::print(
+            "TD3: OU noise is used for target policy smoothing. OU noise is temporally correlated and violates "
+            "the i.i.d. assumption required by TD3 target policy smoothing. This can bias Q-value targets across "
+            "training steps. Consider using parameter_noise (i.i.d. Gaussian) for the training noise instead.",
+            torchfort::logging::warn);
       } else {
         THROW_INVALID_USAGE(noise_actor_type);
       }
@@ -511,13 +533,13 @@ torch::Tensor TD3System::evaluate(torch::Tensor state, torch::Tensor action) {
   torch::NoGradGuard no_grad;
 
   // prepare inputs
-  q_models_target_[0].model->to(model_device_);
-  q_models_target_[0].model->eval();
+  q_models_[0].model->to(model_device_);
+  q_models_[0].model->eval();
   state = state.to(model_device_);
   action = action.to(model_device_);
 
   // do fwd pass
-  torch::Tensor reward = (q_models_target_[0].model)->forward(std::vector<torch::Tensor>{state, action})[0];
+  torch::Tensor reward = (q_models_[0].model)->forward(std::vector<torch::Tensor>{state, action})[0];
 
   // squeeze
   reward = torch::squeeze(reward, 1);

--- a/src/csrc/rl/on_policy/ppo.cpp
+++ b/src/csrc/rl/on_policy/ppo.cpp
@@ -51,6 +51,11 @@ PPOSystem::PPOSystem(const char* name, const YAML::Node& system_node, int model_
     target_kl_divergence_ = params.get_param<float>("target_kl_divergence")[0];
     epsilon_ = params.get_param<float>("epsilon", 0.2)[0];
     clip_q_ = params.get_param<float>("clip_q", 0.)[0];
+    // entropy regularization coefficient; 0 disables it (default).
+    // A value of 0.01 is a common starting point, especially for discrete action spaces
+    // where the policy can otherwise collapse to a single action early in training.
+    // For continuous action spaces the Gaussian policy spreads naturally via log_sigma,
+    // so 0 is often sufficient there.
     entropy_loss_coeff_ = params.get_param<float>("entropy_loss_coefficient", 0.0)[0];
     value_loss_coeff_ = params.get_param<float>("value_loss_coefficient", 0.5)[0];
     normalize_advantage_ = params.get_param<bool>("normalize_advantage", true)[0];
@@ -170,8 +175,8 @@ void PPOSystem::printInfo() const {
   std::cout << "batch_size = " << batch_size_ << std::endl;
   std::cout << "epsilon = " << epsilon_ << std::endl;
   std::cout << "clip_q = " << clip_q_ << std::endl;
-  std::cout << "entropy_loss_coefficient" << entropy_loss_coeff_ << std::endl;
-  std::cout << "value_loss_coefficient" << value_loss_coeff_ << std::endl;
+  std::cout << "entropy_loss_coefficient = " << entropy_loss_coeff_ << std::endl;
+  std::cout << "value_loss_coefficient = " << value_loss_coeff_ << std::endl;
   std::cout << "normalize_advantage = " << normalize_advantage_ << std::endl;
   std::cout << "a_low = " << a_low_ << std::endl;
   std::cout << "a_high = " << a_high_ << std::endl;


### PR DESCRIPTION
This MR adds a few fixes and improvements to the RL code in the branch. Most notably:
- I somehow misunderstood the real use of target vs active networks. The latter are the important ones, the former are just for stabilization and should never be used externally, i.e. during inference. I fixed this throughout the code. This can be considered a critical fix and should improve skill drastically. 
- In SAC, target_entropy was not correctly wired up in the interface and always ignored
- Fixed some warnings/errors.
- added comments for practitioners about useful parameter choice. 
- added missing DDP all-reduces for loss reporting in some algorithms. This is not a problem for training, just a reporting problem.
- In DDPG and SAC, the polka update was not tuned to the optimizer updates when using gradient accumulation. This was fixed. For the other algorithms this was already correct.