### PR TITLE
Update Dockerfile_gnu to CUDA 13.2 / torch 2.12.1, move both to Ubuntu 24.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM  nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu22.04
+FROM  nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -13,15 +13,15 @@ RUN apt update -y && \
     apt install -y vim gfortran
 
 # Install PyTorch (and select dependencies)
-RUN pip3 install typing_extensions && \
-    pip3 install --no-deps torch==2.12.1 --index-url https://download.pytorch.org/whl/cu132 && \
-    pip3 install --no-deps nvidia-cudnn-cu13==9.20.0.48 nvidia-cusparselt-cu13==0.8.1 nvidia-nccl-cu13==2.29.7 nvidia-cufile==1.18.1.6
+RUN pip3 install --break-system-packages typing_extensions && \
+    pip3 install --break-system-packages --no-deps torch==2.12.1 --index-url https://download.pytorch.org/whl/cu132 && \
+    pip3 install --break-system-packages --no-deps nvidia-cudnn-cu13==9.20.0.48 nvidia-cusparselt-cu13==0.8.1 nvidia-nccl-cu13==2.29.7 nvidia-cufile==1.18.1.6
 
 # Remove conflicting NCCL version from NVHPC SDK, add libnccl.so symlink to pip installed NCCL
 RUN rm -rf /opt/nvidia/hpc_sdk/Linux_x86_64/26.5/comm_libs/nccl/ && \
-    cd /usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib && \
+    cd /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib && \
     ln -s libnccl.so.2 libnccl.so
-ENV LD_LIBRARY_PATH /usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib:$LD_LIBRARY_PATH
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
@@ -35,7 +35,7 @@ RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
 ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
 
 # Install additional Python dependencies
-RUN pip3 install wandb ruamel-yaml matplotlib pygame moviepy
+RUN pip3 install --break-system-packages wandb ruamel-yaml matplotlib pygame moviepy
 
 # Install TorchFort
 ENV FC=nvfortran
@@ -45,7 +45,7 @@ RUN cd /torchfort && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/torchfort \
     -DCMAKE_CXX_COMPILER=`which g++` \
     -DTORCHFORT_YAML_CPP_ROOT=/opt/yaml-cpp \
-    -DTORCHFORT_NCCL_ROOT=/usr/local/lib/python3.10/dist-packages/nvidia/nccl \
+    -DTORCHFORT_NCCL_ROOT=/usr/local/lib/python3.12/dist-packages/nvidia/nccl \
     -DTORCHFORT_BUILD_EXAMPLES=1 \
     -DTORCHFORT_BUILD_TESTS=1 \
     -DCMAKE_PREFIX_PATH="`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`" \
@@ -53,4 +53,4 @@ RUN cd /torchfort && mkdir build && cd build && \
     make -j$(nproc) install && \
     cd / && rm -rf torchfort
 ENV LD_LIBRARY_PATH /opt/torchfort/lib:${LD_LIBRARY_PATH}
-ENV LD_LIBRARY_PATH /usr/local/lib/python3.10/dist-packages/torch/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH /usr/local/lib/python3.12/dist-packages/torch/lib:${LD_LIBRARY_PATH}

--- a/docker/Dockerfile_gnu
+++ b/docker/Dockerfile_gnu
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.9.1-devel-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:13.2.0-devel-ubuntu24.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -14,19 +14,20 @@ RUN apt update -y && \
 
 # Download HPCX
 RUN cd /opt && \
-    wget https://content.mellanox.com/hpc/hpc-x/v2.24.1_cuda12/hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz && \
-    tar xjf hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz && \
-    mv hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64 hpcx && \
-    cd /opt && rm hpcx-v2.24.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz
+    wget https://content.mellanox.com/hpc/hpc-x/v2.24.1_cuda13/hpcx-v2.24.1-gcc-doca_ofed-ubuntu24.04-cuda13-x86_64.tbz && \
+    tar xjf hpcx-v2.24.1-gcc-doca_ofed-ubuntu24.04-cuda13-x86_64.tbz && \
+    mv hpcx-v2.24.1-gcc-doca_ofed-ubuntu24.04-cuda13-x86_64 hpcx && \
+    cd /opt && rm hpcx-v2.24.1-gcc-doca_ofed-ubuntu24.04-cuda13-x86_64.tbz
 
 ENV PATH /opt/hpcx/ompi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
 
 RUN echo "source /opt/hpcx/hpcx-init.sh; hpcx_load" >>  /root/.bashrc
 
-# Install PyTorch
-RUN pip3 install --no-deps torch==2.8.0 --index-url https://download.pytorch.org/whl/cu129 && \
-    pip3 install --no-deps nvidia-cudnn-cu12==9.10.2.21 nvidia-cusparselt-cu12==0.7.1 nvidia-cufile-cu12==1.14.1.1
+# Install PyTorch (and select dependencies)
+RUN pip3 install --break-system-packages typing_extensions && \
+    pip3 install --break-system-packages --no-deps torch==2.12.1 --index-url https://download.pytorch.org/whl/cu132 && \
+    pip3 install --break-system-packages --no-deps nvidia-cudnn-cu13==9.20.0.48 nvidia-cusparselt-cu13==0.8.1 nvidia-cufile==1.18.1.6
 
 # Install yaml-cpp
 RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
@@ -40,7 +41,7 @@ RUN git clone https://github.com/jbeder/yaml-cpp.git --branch 0.8.0 && \
 ENV LD_LIBRARY_PATH /opt/yaml-cpp/lib:${LD_LIBRARY_PATH}
 
 # Install additional Python dependencies
-RUN pip3 install wandb ruamel-yaml matplotlib pygame moviepy
+RUN pip3 install --break-system-packages wandb ruamel-yaml matplotlib pygame moviepy
 
 # Install TorchFort
 ENV FC=gfortran
@@ -56,4 +57,4 @@ RUN source /opt/hpcx/hpcx-init.sh &&  hpcx_load && \
     make -j$(nproc) install && \
     cd / && rm -rf torchfort
 ENV LD_LIBRARY_PATH /opt/torchfort/lib:${LD_LIBRARY_PATH}
-ENV LD_LIBRARY_PATH /usr/local/lib/python3.10/dist-packages/torch/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH /usr/local/lib/python3.12/dist-packages/torch/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
Mirrors the CUDA 13.2 + torch 2.12.1 upgrade (already done in `Dockerfile`) into `Dockerfile_gnu`, and moves **both** images to Ubuntu 24.04.

## Dockerfile_gnu
- Base image `nvcr.io/nvidia/cuda:12.9.1-devel-ubuntu22.04` → `13.2.0-devel-ubuntu24.04`
- HPCX `v2.24.1_cuda12`/ubuntu22.04 → `v2.24.1_cuda13`/ubuntu24.04 build
- torch `2.8.0`/cu129 → `2.12.1`/cu132; deps bumped to `-cu13` (cudnn 9.20.0.48, cusparselt 0.8.1, cufile 1.18.1.6); add `typing_extensions`

## Both Dockerfiles (Ubuntu 24.04 fallout)
Ubuntu 24.04 ships Python 3.12 (PEP 668, externally managed), so:
- `--break-system-packages` added to all `pip3 install` calls
- hardcoded `python3.10` dist-packages paths → `python3.12`

Availability of the 24.04 nvhpc base, the 24.04/cuda13 HPCX tarball, and the cuda 13.2.0 base image was verified before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)